### PR TITLE
Fix GitHub Action certificate trust issue

### DIFF
--- a/.github/workflows/pr-build-packages.yml
+++ b/.github/workflows/pr-build-packages.yml
@@ -74,6 +74,34 @@ jobs:
           Write-Host "Full Version: ${{ steps.version.outputs.version }}" -ForegroundColor Yellow
           Write-Host "================================================" -ForegroundColor Cyan
 
+      - name: Create and trust development certificate
+        shell: pwsh
+        run: |
+          Write-Host "Creating development certificate for HTTPS..."
+
+          # Clean any existing dev certs
+          dotnet dev-certs https --clean
+
+          # Create a new dev certificate
+          dotnet dev-certs https --export-path $env:TEMP\aspnetcore-dev-cert.pfx --password "DevCertPassword" --trust
+
+          # Import the certificate into the trusted root store
+          $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2("$env:TEMP\aspnetcore-dev-cert.pfx", "DevCertPassword")
+          $store = New-Object System.Security.Cryptography.X509Certificates.X509Store("Root", "CurrentUser")
+          $store.Open("ReadWrite")
+          $store.Add($cert)
+          $store.Close()
+
+          Write-Host "Development certificate created and added to trusted root store" -ForegroundColor Green
+
+          # Verify the certificate
+          dotnet dev-certs https --check --trust
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "Certificate verification successful" -ForegroundColor Green
+          } else {
+            Write-Host "Certificate verification failed, but continuing..." -ForegroundColor Yellow
+          }
+
       - name: Run CreateNuGetPackages script
         shell: pwsh
         run: |


### PR DESCRIPTION
Added step to create and trust development certificate in the PR build workflow.
The Umbraco application requires HTTPS with a trusted certificate to run locally.
This fix programmatically creates and imports the dev certificate into the trusted
root store, which works in non-interactive CI/CD environments.