### PR TITLE
Fix HTTPS certificate validation for GitHub Actions

### DIFF
--- a/.github/workflows/pr-build-packages.yml
+++ b/.github/workflows/pr-build-packages.yml
@@ -20,10 +20,6 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: Install SSL Certificates
-        run: |
-          dotnet dev-certs https --trust
-
       - name: Get latest NuGet version and create build version
         id: version
         shell: pwsh


### PR DESCRIPTION
The previous approach of using 'dotnet dev-certs https --trust' doesn't work in
GitHub Actions on Windows because it requires interactive user consent.

This commit implements the proper solution for CI/CD environments:

1. Added certificate validation bypass in CreateNuGetPackages.ps1:
   - For Windows PowerShell 5.x: Uses ServicePointManager with custom CertificatePolicy
   - For PowerShell Core 6+: Uses -SkipCertificateCheck parameter on HTTP calls

2. Updated all HTTPS calls to localhost to support certificate bypass:
   - Invoke-WebRequest for health check
   - Invoke-RestMethod for token retrieval
   - Invoke-RestMethod for package info API
   - Invoke-RestMethod for package download

3. Removed ineffective 'Install SSL Certificates' step from workflow

This approach follows the pattern used in other CI/CD workflows where localhost
HTTPS calls are made to a self-signed development certificate. The validation
bypass is safe in this context as both client and server are controlled by the
build process.