### PR TITLE
Fix template-pack.csproj image path for NuGet packaging

### DIFF
--- a/template-pack.csproj
+++ b/template-pack.csproj
@@ -25,6 +25,6 @@
     <Content Include="template\**\*" Exclude="template\**\bin\**;template\**\obj\**,template\.vs\**,template\**\created-packages\**" />
     <Compile Remove="**\*" />
     <None Include="README.md" Pack="true" PackagePath="\" />
-    <None Include="images\logo.png" Pack="true" PackagePath="\" />
+    <None Include="template\images\logo.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Problem
The dotnet pack command was failing with the error: "Could not find a part of the path 'D:\a\Clean\Clean\images'"

This occurred because template-pack.csproj:28 was referencing 'images\logo.png', but the images folder doesn't exist at the root level of the repository.

## Root Cause
The images folder is located at 'template/images/', not at the root level 'images/'. The pack configuration was looking in the wrong location.

## Solution
Updated template-pack.csproj line 28:
- Before: <None Include="images\logo.png" Pack="true" PackagePath="\" />
- After:  <None Include="template\images\logo.png" Pack="true" PackagePath="\" />

## Verification
✓ Confirmed template/images/logo.png exists
✓ Confirmed images/logo.png does NOT exist at root (was the issue)

The Umbraco.Community.Templates.Clean package will now successfully include the logo.png file when built with dotnet pack.