### PR TITLE
feat: Auto-commit version updates to main after release

### DIFF
--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish-release:
     runs-on: windows-latest
+    permissions:
+      contents: write  # Allow pushing to main branch
 
     steps:
       - name: Checkout repository
@@ -154,6 +156,59 @@ jobs:
               Write-Host "⚠️  Failed to upload $($pkg.Name)" -ForegroundColor Yellow
             }
           }
+
+      - name: Commit version updates to main branch
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          Write-Host "================================================" -ForegroundColor Cyan
+          Write-Host "Committing Version Updates to Main Branch" -ForegroundColor Cyan
+          Write-Host "================================================" -ForegroundColor Cyan
+
+          # Configure git with bot user
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Fetch and switch to main branch
+          Write-Host "Fetching main branch..." -ForegroundColor Yellow
+          git fetch origin main
+
+          Write-Host "Switching to main branch..." -ForegroundColor Yellow
+          git switch main
+
+          # Check if there are any changes to commit
+          $gitStatus = git status --porcelain
+          if ([string]::IsNullOrWhiteSpace($gitStatus)) {
+            Write-Host "No changes to commit - versions are already up to date" -ForegroundColor Yellow
+            exit 0
+          }
+
+          # Show what files will be committed
+          Write-Host "`nModified files:" -ForegroundColor Cyan
+          git status --short
+
+          # Stage all .csproj files
+          Write-Host "`nStaging .csproj files..." -ForegroundColor Yellow
+          git add "**/*.csproj"
+
+          # Commit with skip ci flag to prevent triggering other workflows
+          $commitMessage = "chore: Update versions to ${{ steps.version.outputs.version }} [skip ci]"
+          Write-Host "`nCommitting changes with message: $commitMessage" -ForegroundColor Yellow
+          git commit -m $commitMessage
+
+          # Push to main
+          Write-Host "`nPushing to main branch..." -ForegroundColor Yellow
+          git push origin main
+
+          if ($LASTEXITCODE -eq 0) {
+            Write-Host "✅ Successfully pushed version updates to main branch" -ForegroundColor Green
+          } else {
+            Write-Host "❌ Failed to push to main branch (exit code: $LASTEXITCODE)" -ForegroundColor Red
+            exit 1
+          }
+
+          Write-Host "================================================" -ForegroundColor Cyan
 
       - name: Release Summary
         if: always()

--- a/VERSIONING-AND-RELEASES.md
+++ b/VERSIONING-AND-RELEASES.md
@@ -212,7 +212,10 @@ When you publish a release, the `release-nuget.yml` workflow:
    - Umbraco.Community.Templates.Clean
 6. **Publishes** to NuGet.org
 7. **Uploads** `.nupkg` files to GitHub Release assets
-8. **Reports** success or failure
+8. **Commits** version updates to `main` branch (automatically, without triggering other workflows)
+9. **Reports** success or failure
+
+> **Note**: The version updates are automatically committed back to the `main` branch after a successful release. This ensures that anyone cloning the repository will see the latest released versions in the `.csproj` files. This commit does not trigger any workflows, preventing circular pipeline runs.
 
 ### Post-Release Verification
 
@@ -289,7 +292,8 @@ The Clean packages maintain version alignment with Umbraco CMS:
 3. Build packages with release version
 4. Publish to NuGet.org (requires `NUGET_API_KEY`)
 5. Upload to release assets
-6. Generate summary
+6. Commit version updates to `main` branch (with `[skip ci]` to prevent triggering workflows)
+7. Generate summary
 
 **Example**:
 - Release tag: `v7.0.0`
@@ -300,6 +304,12 @@ The Clean packages maintain version alignment with Umbraco CMS:
 - Official releases
 - Public distribution
 - Production deployments
+
+**Important Notes**:
+- Version changes are automatically committed directly to `main` after successful release
+- The commit message includes `[skip ci]` to prevent triggering other workflows
+- Uses `github-actions[bot]` as the commit author
+- This ensures developers cloning the repo see the latest released versions
 
 ## Troubleshooting
 


### PR DESCRIPTION
- Modified release-nuget.yml to commit .csproj version changes back to main
- Added permissions: contents: write to allow pushing to main
- Commit includes [skip ci] flag to prevent triggering other workflows
- Uses github-actions[bot] as commit author
- Updated VERSIONING-AND-RELEASES.md to document this behavior
- Ensures developers cloning repo see latest released versions

This change addresses the issue where the main branch had stale version
numbers after releases. Now the workflow automatically updates main with
the released versions without triggering circular pipeline runs.