### PR TITLE
feat: Schedule NuGet version check to run daily at 8am UK time

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -1,6 +1,8 @@
 name: Update NuGet Packages
 
 on:
+  schedule:
+    - cron: '0 8 * * *'  # Run daily at 8am UTC (8am UK time in winter, 9am in summer)
   workflow_dispatch:
     inputs:
       dryRun:


### PR DESCRIPTION
- Add cron schedule to run daily at 8am UTC (8am GMT/9am BST)
- Retain manual workflow_dispatch trigger for on-demand runs