### PR TITLE
fix: Use GitHub package feed instead of local csproj for testing

### DIFF
--- a/.github/workflows/pr-build-packages.yml
+++ b/.github/workflows/pr-build-packages.yml
@@ -195,19 +195,7 @@ jobs:
           $sourceUrl = "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
           dotnet nuget add source $sourceUrl --name "GitHubPackages" --username "${{ github.repository_owner }}" --password "$env:GITHUB_TOKEN" --store-password-in-clear-text
 
-          # Read Umbraco version from Clean.csproj to determine which template version to use
-          Write-Host "`nDetermining Umbraco version from Clean package..." -ForegroundColor Yellow
-          $cleanCsprojPath = "${{ github.workspace }}\template\Clean\Clean.csproj"
-          [xml]$cleanCsproj = Get-Content $cleanCsprojPath
-          $umbracoPackageRef = $cleanCsproj.Project.ItemGroup.PackageReference | Where-Object { $_.Include -eq "Umbraco.Cms.Web.Website" }
-          $umbracoVersion = $umbracoPackageRef.Version
-          Write-Host "Umbraco version: $umbracoVersion" -ForegroundColor Green
-
-          # Install Umbraco templates for the detected version
-          Write-Host "`nInstalling Umbraco templates version $umbracoVersion..." -ForegroundColor Yellow
-          dotnet new install Umbraco.Templates::$umbracoVersion --force
-
-          # Create Umbraco project
+          # Create Umbraco project first (will install default templates)
           Write-Host "`nCreating test Umbraco project..." -ForegroundColor Yellow
           dotnet new sln --name "TestSolution"
           dotnet new umbraco --force -n "TestProject" --friendly-name "Administrator" --email "admin@example.com" --password "1234567890" --development-database-type SQLite
@@ -216,6 +204,21 @@ jobs:
           # Install Clean package from GitHub Packages
           Write-Host "`nInstalling Clean package version ${{ steps.version.outputs.version }} from GitHub Packages..." -ForegroundColor Yellow
           dotnet add "TestProject" package Clean --version "${{ steps.version.outputs.version }}" --source "GitHubPackages"
+
+          # Determine Umbraco version from the installed Clean package
+          Write-Host "`nDetermining Umbraco version from installed Clean package..." -ForegroundColor Yellow
+          Set-Location "TestProject"
+          [xml]$testCsproj = Get-Content "TestProject.csproj"
+          $umbracoPackageRef = $testCsproj.Project.ItemGroup.PackageReference | Where-Object { $_.Include -eq "Umbraco.Cms.Web.Website" }
+          $umbracoVersion = $umbracoPackageRef.Version
+          Write-Host "Umbraco version from package: $umbracoVersion" -ForegroundColor Green
+          Set-Location ..
+
+          # Install Umbraco templates for the detected version if needed
+          if ($umbracoVersion) {
+            Write-Host "`nInstalling Umbraco templates version $umbracoVersion to ensure compatibility..." -ForegroundColor Yellow
+            dotnet new install Umbraco.Templates::$umbracoVersion --force
+          }
 
           # Start the site in background
           Write-Host "`nStarting Umbraco site..." -ForegroundColor Yellow


### PR DESCRIPTION
- Remove reference to local Clean.csproj in workflow
- Install Clean package from GitHub Packages first
- Extract Umbraco version from installed package dependencies
- Ensures workflow tests the actual package from the feed