### PR TITLE
fix: Use modern @ syntax for Umbraco template installation

### DIFF
--- a/.github/workflows/pr-build-packages.yml
+++ b/.github/workflows/pr-build-packages.yml
@@ -205,7 +205,7 @@ jobs:
 
           # Install Umbraco templates for the detected version
           Write-Host "`nInstalling Umbraco templates version $umbracoVersion..." -ForegroundColor Yellow
-          dotnet new install Umbraco.Templates::$umbracoVersion --force
+          dotnet new install Umbraco.Templates@$umbracoVersion --force
 
           # Create Umbraco project
           Write-Host "`nCreating test Umbraco project..." -ForegroundColor Yellow


### PR DESCRIPTION
Update the Umbraco template installation command from the deprecated :: syntax
to the modern @ syntax. This addresses the deprecation warning and ensures
the correct Umbraco Project template (not docker-compose) is used during
the PR build and test workflow.

The dotnet new umbraco command already correctly specifies the unattended
installation parameters (--friendly-name, --email, --password,
--development-database-type SQLite) for automated testing.