### PR TITLE
fix: Check and remove existing NuGet source before adding in test step

### DIFF
--- a/.github/workflows/pr-build-packages.yml
+++ b/.github/workflows/pr-build-packages.yml
@@ -193,6 +193,14 @@ jobs:
           # Configure GitHub Packages as NuGet source
           Write-Host "`nConfiguring GitHub Packages as NuGet source..." -ForegroundColor Yellow
           $sourceUrl = "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+
+          # Check if source already exists
+          $existingSources = dotnet nuget list source
+          if ($existingSources -match "GitHubPackages") {
+            Write-Host "GitHubPackages source already exists, removing it first..." -ForegroundColor Yellow
+            dotnet nuget remove source "GitHubPackages"
+          }
+
           dotnet nuget add source $sourceUrl --name "GitHubPackages" --username "${{ github.repository_owner }}" --password "$env:GITHUB_TOKEN" --store-password-in-clear-text
 
           # Read Umbraco version from Clean.csproj to determine which template version to use


### PR DESCRIPTION
The PR workflow was failing with "The name specified has already been added
to the list of available package sources" because the GitHubPackages source
was being added twice - once in the publish step and again in the test step.

This fix adds a check in the test step to see if the GitHubPackages source
already exists, and if so, removes it before adding it again. This prevents
the duplicate source error and allows the package installation test to proceed.