### PR TITLE
fix: Use source URL instead of source name for NuGet package installation

### DIFF
--- a/.github/workflows/pr-build-packages.yml
+++ b/.github/workflows/pr-build-packages.yml
@@ -223,7 +223,7 @@ jobs:
 
           # Install Clean package from GitHub Packages
           Write-Host "`nInstalling Clean package version ${{ steps.version.outputs.version }} from GitHub Packages..." -ForegroundColor Yellow
-          dotnet add "TestProject" package Clean --version "${{ steps.version.outputs.version }}" --source "GitHubPackages"
+          dotnet add "TestProject" package Clean --version "${{ steps.version.outputs.version }}" --source $sourceUrl
 
           # Start the site in background
           Write-Host "`nStarting Umbraco site..." -ForegroundColor Yellow


### PR DESCRIPTION
The previous implementation used --source "GitHubPackages" which NuGet
was interpreting as a local path instead of a named source, causing the
error "NU1301: The local source 'D:\a\Clean\Clean\test-installation\GitHubPackages' doesn't exist."

Changed to use the actual source URL ($sourceUrl) directly, which is more
reliable and avoids the source name resolution issue.