### PR TITLE
fix: Rename package test screenshots artifact to be more descriptive

### DIFF
--- a/.github/workflows/pr-build-packages.yml
+++ b/.github/workflows/pr-build-packages.yml
@@ -398,7 +398,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-screenshots-${{ steps.version.outputs.version }}
+          name: package-test-screenshots-${{ steps.version.outputs.version }}
           path: test-installation/screenshots/*.png
           if-no-files-found: warn
 

--- a/PR-WORKFLOW.md
+++ b/PR-WORKFLOW.md
@@ -107,7 +107,7 @@ The workflow uploads the following artifacts for every PR:
 | Artifact | Description | Naming Pattern |
 |----------|-------------|----------------|
 | NuGet Packages | All four `.nupkg` files | `nuget-packages-{version}` |
-| Package Test Screenshots | Screenshots from package installation test | `playwright-screenshots-{version}` |
+| Package Test Screenshots | Screenshots from package installation test | `package-test-screenshots-{version}` |
 | Template Test Screenshots | Screenshots from template installation test | `template-screenshots-{version}` |
 
 **Access**: Available in the "Actions" tab of the PR for download and review.
@@ -285,7 +285,7 @@ When reviewing a PR, check:
 4. Scroll to "Artifacts" section
 5. Download:
    - `nuget-packages-{version}` - The actual .nupkg files
-   - `playwright-screenshots-{version}` - Package test screenshots
+   - `package-test-screenshots-{version}` - Package test screenshots
    - `template-screenshots-{version}` - Template test screenshots
 
 ## Troubleshooting


### PR DESCRIPTION
Changed the artifact name from 'playwright-screenshots' to
'package-test-screenshots' to clearly distinguish it from the
template test screenshots. This makes it consistent with the
naming pattern where template screenshots are called
'template-screenshots'.

Also updated the PR-WORKFLOW.md documentation to reflect
this change in both the artifacts table and the accessing
artifacts section.