### PR TITLE
fix: Remove deprecated PackageIconUrl property from project files

### DIFF
--- a/template/Clean.Core/Clean.Core.csproj
+++ b/template/Clean.Core/Clean.Core.csproj
@@ -13,7 +13,6 @@
     <PackageTags>umbraco plugin package starter kit Clean core library</PackageTags>
     <PackageProjectUrl>https://github.com/prjseal/Clean</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <PackageIconUrl>https://github.com/prjseal/Clean/blob/master/images/logo.png?raw=true</PackageIconUrl>
     <RepositoryUrl>https://github.com/prjseal/Clean</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/template/Clean.Headless/Clean.Headless.csproj
+++ b/template/Clean.Headless/Clean.Headless.csproj
@@ -14,7 +14,6 @@
     <PackageTags>umbraco plugin package starter kit Clean core library headless</PackageTags>
     <PackageProjectUrl>https://github.com/prjseal/Clean</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <PackageIconUrl>https://github.com/prjseal/Clean/blob/master/images/logo.png?raw=true</PackageIconUrl>
     <RepositoryUrl>https://github.com/prjseal/Clean</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/template/Clean/Clean.csproj
+++ b/template/Clean/Clean.csproj
@@ -12,7 +12,6 @@
     <Description>Clean Starter Kit for Umbraco</Description>
     <PackageProjectUrl>https://github.com/prjseal/Clean</PackageProjectUrl>
     <PackageIcon>logo.png</PackageIcon>
-    <PackageIconUrl>https://github.com/prjseal/Clean/blob/master/images/logo.png?raw=true</PackageIconUrl>
     <RepositoryUrl>https://github.com/prjseal/Clean</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Removed the deprecated PackageIconUrl element from Clean.csproj, Clean.Core.csproj, and Clean.Headless.csproj to resolve NU5048 build warnings. The projects already use the recommended PackageIcon element with the logo.png file.