### PR TITLE
fix: Default includePrerelease to true for scheduled NuGet updates

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -37,7 +37,8 @@ jobs:
         shell: pwsh
         run: |
           $dryRunFlag = if ('${{ github.event.inputs.dryRun }}' -eq 'true') { $true } else { $false }
-          $includePrereleaseFlag = if ('${{ github.event.inputs.includePrerelease }}' -eq 'true') { $true } else { $false }
+          # Default to true for scheduled runs (when input is empty), only false if explicitly set to 'false'
+          $includePrereleaseFlag = if ('${{ github.event.inputs.includePrerelease }}' -eq 'false') { $false } else { $true }
 
           Write-Host "DryRunFlag = $dryRunFlag"
           Write-Host "IncludePrereleaseFlag = $includePrereleaseFlag"


### PR DESCRIPTION
The update-packages workflow was failing to include pre-release versions
when running on schedule because the includePrerelease parameter defaults
to empty string for scheduled runs, which was being interpreted as false.

Changed the logic to:
- Default to true when parameter is not provided (scheduled runs)
- Only set to false when explicitly set to 'false' (manual runs)

This ensures scheduled runs will pick up RC versions like Umbraco v17 RC,
fixing the TypeLoadException errors with Umbraco.Cms.Persistence.SqlServer.