### PR TITLE
fix: Add pull-requests write permission to release workflow

### DIFF
--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -8,7 +8,8 @@ jobs:
   publish-release:
     runs-on: windows-latest
     permissions:
-      contents: write  # Allow pushing to main branch
+      contents: write       # Allow pushing branches and uploading release assets
+      pull-requests: write  # Allow creating pull requests
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The release workflow creates a pull request with version updates, but the default GITHUB_TOKEN lacks permission to create PRs.

This change adds the pull-requests: write permission to allow the workflow to successfully create pull requests.

Fixes error: "GraphQL: Resource not accessible by integration (createPullRequest)"