### PR TITLE
fix: Include root-level .csproj files in version update PRs

### DIFF
--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -308,7 +308,7 @@ jobs:
 
           # Stage all .csproj and README.md files
           Write-Host "`nStaging .csproj files..." -ForegroundColor Yellow
-          git add "**/*.csproj"
+          git add "*.csproj" "**/*.csproj"
 
           Write-Host "Staging README.md files..." -ForegroundColor Yellow
           git add "README.md" "template/README.md"


### PR DESCRIPTION
The release workflow was using `git add "**/*.csproj"` which only matches
.csproj files in subdirectories, missing template-pack.csproj at the root.

This fix adds `"*.csproj"` to the git add command to ensure root-level
.csproj files (like template-pack.csproj) are included in version update PRs.