### PR TITLE
fix: Update build badge to use release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NuGet Version](https://img.shields.io/nuget/v/Clean?label=NuGet%20Version)](https://www.nuget.org/packages/Clean)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Clean?label=NuGet%20Downloads)](https://www.nuget.org/packages/Clean)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/prjseal/Clean/pr-build-packages.yml?branch=main&label=Build)](https://github.com/prjseal/Clean/actions)
+[![Release Build](https://img.shields.io/github/actions/workflow/status/prjseal/Clean/release-nuget.yml?label=Release%20Build)](https://github.com/prjseal/Clean/actions)
 [![License](https://img.shields.io/github/license/prjseal/Clean?label=License)](https://github.com/prjseal/Clean/blob/main/LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/prjseal/Clean?label=Stars)](https://github.com/prjseal/Clean/stargazers)
 


### PR DESCRIPTION
The previous build badge pointed to the PR workflow with branch=main, which always showed as failing because that workflow only runs on pull requests, not on the main branch. Changed to use the release workflow instead, which provides a more accurate representation of the project's build health.