### PR TITLE
Fix: Show build errors and prevent PR creation when builds fail

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -222,8 +222,34 @@ jobs:
             -DryRun:$dryRunFlag `
             -IncludePrerelease:$includePrereleaseFlag
 
+      - name: Build Failure Summary
+        if: failure() && steps.update-packages.conclusion == 'failure'
+        shell: pwsh
+        run: |
+          Write-Host "================================================" -ForegroundColor Red
+          Write-Host "❌ UPDATE PACKAGES WORKFLOW FAILED" -ForegroundColor Red
+          Write-Host "================================================" -ForegroundColor Red
+          Write-Host ""
+          Write-Host "The UpdateThirdPartyPackages script encountered build failures." -ForegroundColor Yellow
+          Write-Host ""
+          Write-Host "📋 Build Summary:" -ForegroundColor Cyan
+          $buildSummaryPath = "${{ github.workspace }}\.artifacts\build-summary.txt"
+          if (Test-Path $buildSummaryPath) {
+            $buildSummary = Get-Content $buildSummaryPath -Raw
+            Write-Host $buildSummary
+          } else {
+            Write-Host "Build summary file not found." -ForegroundColor Yellow
+          }
+          Write-Host ""
+          Write-Host "🔍 Check the logs above for detailed error messages." -ForegroundColor Cyan
+          Write-Host "📂 Build logs are saved in .artifacts/logs/ directory." -ForegroundColor Cyan
+          Write-Host ""
+          Write-Host "No PR will be created due to build failures." -ForegroundColor Yellow
+          Write-Host "================================================" -ForegroundColor Red
+
       - name: Check if any changes were made
         id: check-changes
+        if: success()
         shell: pwsh
         run: |
           $readmeUpdated = '${{ steps.update-readme.outputs.readme_updated }}' -eq 'true'


### PR DESCRIPTION
This addresses the issue where build failures weren't visible and PRs were still created.

Problems Fixed:
1. Build errors weren't displayed - only file paths were shown
2. Script completed successfully even when builds failed
3. Workflow created PRs despite build failures

Changes to UpdateThirdPartyPackages.ps1:
- Display last 50 lines of build output with errors highlighted in red
- Show clear "BUILD FAILED" banner with solution name
- Exit with code 1 when any builds fail
- Add success message when all builds pass

Changes to update-packages.yml:
- Add 'if: success()' to "Check if any changes were made" step
- Add "Build Failure Summary" step that runs on failure
- Display build summary file when failures occur
- Prevents PR creation when builds fail

Now when builds fail:
- Detailed error output is shown in console
- Build summary table shows which solutions failed
- Script exits with error code 1
- Workflow stops and doesn't create a PR
- Clear failure message explains what happened