### PR TITLE
fix: Properly escape all XML special characters in BlockList labels

### DIFF
--- a/.github/workflows/powershell/CreateNuGetPackages.ps1
+++ b/.github/workflows/powershell/CreateNuGetPackages.ps1
@@ -81,8 +81,8 @@ function Fix-BlockListLabels {
         # Unicode-escape single quotes to match Umbraco format
         $modifiedJson = $modifiedJson -replace "'", '\u0027'
 
-        # HTML-encode for XML attribute
-        $modifiedEncoded = $modifiedJson -replace '"', '&quot;'
+        # HTML-encode for XML attribute (properly escape all special XML characters: <, >, &, ", ')
+        $modifiedEncoded = [System.Web.HttpUtility]::HtmlEncode($modifiedJson)
 
         # Replace in the original XML content
         $prefix = $match.Groups[1].Value


### PR DESCRIPTION
The previous implementation only escaped double quotes (&quot;) when encoding BlockList labels for the package.xml file. This caused XML parsing errors when labels contained other special characters like <, >, or &.

Changes:
- Replaced simple quote replacement with System.Web.HttpUtility.HtmlEncode()
- Now properly escapes all XML special characters:
  - < becomes &lt;
  - > becomes &gt;
  - & becomes &amp;
  - " becomes &quot;
  - ' becomes &#39;

This fixes the error: '<', hexadecimal value 0x3C, is an invalid attribute character