### PR TITLE
fix: Update release workflow to properly handle marketplace readme files

### DIFF
--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -127,8 +127,6 @@ jobs:
               "umbraco-marketplace-readme-clean.md"
             )
 
-            $umbracoSectionHeader = "## Umbraco $umbracoMajor"
-
             foreach ($readmeFile in $readmeFiles) {
               if (-not (Test-Path $readmeFile)) {
                 Write-Host "⚠️  File not found: $readmeFile" -ForegroundColor Yellow
@@ -137,37 +135,71 @@ jobs:
 
               Write-Host "`nUpdating $readmeFile..." -ForegroundColor Cyan
               $content = Get-Content $readmeFile -Raw
+              $originalContent = $content
 
-              # Find the section for this Umbraco version
-              if ($content -match "(?s)$umbracoSectionHeader.*?(?=(##|\z))") {
-                $section = $matches[0]
-                $updatedSection = $section
+              # Determine if this is a marketplace readme (different structure)
+              $isMarketplaceReadme = $readmeFile -like "*marketplace*"
 
-                # Update Umbraco.Templates version
-                $updatedSection = $updatedSection -replace "dotnet new install Umbraco\.Templates::\S+", "dotnet new install Umbraco.Templates::$umbracoVersion"
+              if ($isMarketplaceReadme) {
+                # Marketplace readmes use "**For Umbraco X (.NET Y):**" sections
+                # Find and update the section for this Umbraco version
+                $umbracoNetVersion = if ($umbracoMajor -eq 13) { "8" } else { "10" }
+                $marketplaceSectionPattern = "\*\*For Umbraco $umbracoMajor \(\.NET $umbracoNetVersion\):\*\*.*?(?=(\*\*For Umbraco|\z))"
 
-                # Update Clean package version
-                $updatedSection = $updatedSection -replace "(dotnet add .* package Clean --version )\S+", "`${1}$cleanVersion"
+                if ($content -match "(?s)$marketplaceSectionPattern") {
+                  $section = $matches[0]
+                  $updatedSection = $section
 
-                # Update Clean.Core package version (in warning sections)
-                $updatedSection = $updatedSection -replace "(dotnet add .* package Clean\.Core --version )\S+", "`${1}$cleanVersion"
+                  # Update Clean package version
+                  $updatedSection = $updatedSection -replace "(dotnet add .* package Clean\s*(?!\.Core|\.Headless))", "dotnet add `"MyProject`" package Clean"
 
-                # Update Clean template package version
-                $updatedSection = $updatedSection -replace "dotnet new install Umbraco\.Community\.Templates\.Clean::\S+", "dotnet new install Umbraco.Community.Templates.Clean::$cleanVersion"
+                  # Update Clean.Core package version (in warning sections)
+                  $updatedSection = $updatedSection -replace "(dotnet add .* package Clean\.Core --version )\S+", "`${1}$cleanVersion"
 
-                # Replace the section in the content
-                $content = $content -replace [regex]::Escape($section), $updatedSection
+                  # Replace the section in the content
+                  $content = $content -replace [regex]::Escape($section), $updatedSection
 
-                # Write back to file
-                Set-Content -Path $readmeFile -Value $content -NoNewline
-
-                Write-Host "✅ Updated $readmeFile" -ForegroundColor Green
-                Write-Host "   - Umbraco.Templates: $umbracoVersion" -ForegroundColor White
-                Write-Host "   - Clean: $cleanVersion" -ForegroundColor White
-                Write-Host "   - Clean.Core: $cleanVersion" -ForegroundColor White
-                Write-Host "   - Umbraco.Community.Templates.Clean: $cleanVersion" -ForegroundColor White
+                  Write-Host "✅ Updated $readmeFile (marketplace format)" -ForegroundColor Green
+                  Write-Host "   - Clean.Core: $cleanVersion" -ForegroundColor White
+                } else {
+                  Write-Host "⚠️  Could not find section '**For Umbraco $umbracoMajor (.NET $umbracoNetVersion):**' in $readmeFile" -ForegroundColor Yellow
+                }
               } else {
-                Write-Host "⚠️  Could not find section '$umbracoSectionHeader' in $readmeFile" -ForegroundColor Yellow
+                # Main README.md uses "## Umbraco X" section headers
+                $umbracoSectionHeader = "## Umbraco $umbracoMajor"
+
+                if ($content -match "(?s)$umbracoSectionHeader.*?(?=(##|\z))") {
+                  $section = $matches[0]
+                  $updatedSection = $section
+
+                  # Update Umbraco.Templates version
+                  $updatedSection = $updatedSection -replace "dotnet new install Umbraco\.Templates::\S+", "dotnet new install Umbraco.Templates::$umbracoVersion"
+
+                  # Update Clean package version
+                  $updatedSection = $updatedSection -replace "(dotnet add .* package Clean --version )\S+", "`${1}$cleanVersion"
+
+                  # Update Clean.Core package version (in warning sections)
+                  $updatedSection = $updatedSection -replace "(dotnet add .* package Clean\.Core --version )\S+", "`${1}$cleanVersion"
+
+                  # Update Clean template package version
+                  $updatedSection = $updatedSection -replace "dotnet new install Umbraco\.Community\.Templates\.Clean::\S+", "dotnet new install Umbraco.Community.Templates.Clean::$cleanVersion"
+
+                  # Replace the section in the content
+                  $content = $content -replace [regex]::Escape($section), $updatedSection
+
+                  Write-Host "✅ Updated $readmeFile (standard format)" -ForegroundColor Green
+                  Write-Host "   - Umbraco.Templates: $umbracoVersion" -ForegroundColor White
+                  Write-Host "   - Clean: $cleanVersion" -ForegroundColor White
+                  Write-Host "   - Clean.Core: $cleanVersion" -ForegroundColor White
+                  Write-Host "   - Umbraco.Community.Templates.Clean: $cleanVersion" -ForegroundColor White
+                } else {
+                  Write-Host "⚠️  Could not find section '$umbracoSectionHeader' in $readmeFile" -ForegroundColor Yellow
+                }
+              }
+
+              # Write back to file only if content changed
+              if ($content -ne $originalContent) {
+                Set-Content -Path $readmeFile -Value $content -NoNewline
               }
             }
 


### PR DESCRIPTION
The release workflow was not updating the Umbraco marketplace readme files
because it was looking for section headers that don't exist in those files.

Changes:
- Added logic to detect marketplace readme files vs standard README.md
- Marketplace files use "**For Umbraco X (.NET Y):**" sections instead of "## Umbraco X"
- Updated regex patterns to match the correct structure for each file type
- Added better logging to distinguish between file formats

This ensures that when a release is published, all three readme files are
properly updated with the new version numbers:
- README.md (uses "## Umbraco X" sections)
- umbraco-marketplace-readme.md (uses "**For Umbraco X" subsections)
- umbraco-marketplace-readme-clean.md (uses "**For Umbraco X" subsections)

Fixes the issue where PR #157 showed the marketplace files were not being updated.