### PR TITLE
fix: Preserve asterisks in BlockList labels during package creation

### DIFF
--- a/.github/workflows/powershell/CreateNuGetPackages.ps1
+++ b/.github/workflows/powershell/CreateNuGetPackages.ps1
@@ -32,9 +32,8 @@ function Fix-BlockListLabels {
         $labelMap = @{}
         foreach ($block in $usyncConfig.blocks) {
             if ($block.contentElementTypeKey -and $block.label) {
-                # Strip markdown bold markers
-                $label = $block.label -replace '\*\*', ''
-                $labelMap[$block.contentElementTypeKey] = $label
+                # Preserve asterisks for markdown formatting
+                $labelMap[$block.contentElementTypeKey] = $block.label
             }
         }
 


### PR DESCRIPTION
Previously, the script was stripping markdown bold markers (**) from BlockList labels during the package.xml modification process. This caused labels like "**Rich Text**:" to appear as "Rich Text:" in the Umbraco database.

The asterisks are intentional formatting and should be preserved as-is.

Fixes #