### PR TITLE
docs: Create centralized documentation index with links to all guides

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,119 @@
+# Clean Starter Kit - Documentation
+
+Welcome to the comprehensive documentation for the Clean Starter Kit for Umbraco. This page provides links to all available documentation resources to help you use, contribute to, and understand this project.
+
+---
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [For Contributors and Developers](#for-contributors-and-developers)
+- [Package Management](#package-management)
+- [Workflow Documentation](#workflow-documentation)
+- [Technical References](#technical-references)
+
+---
+
+## Getting Started
+
+New to Clean Starter Kit? Start with the main README:
+
+- **[README](README.md)** - Installation instructions, features overview, and quick start guide
+
+---
+
+## For Contributors and Developers
+
+Documentation for those who want to contribute to the Clean Starter Kit project:
+
+### Contributing
+
+- **[Contributing Guide](.github/CONTRIBUTING.md)** - Code standards, testing requirements, and how to submit contributions to the project
+
+### Pull Requests
+
+- **[PR Workflow](.github/PR-WORKFLOW.md)** - Guidelines for creating and reviewing pull requests, including automated workflows and testing procedures
+
+### Versioning and Releases
+
+- **[Versioning and Releases](.github/VERSIONING-AND-RELEASES.md)** - Understanding version numbers, release processes, and how Clean versions map to Umbraco versions
+
+---
+
+## Package Management
+
+Documentation for managing NuGet packages and dependencies:
+
+### Updating Dependencies
+
+- **[Update NuGet Packages](.github/UPDATE-NUGET-PACKAGES.md)** - How to update project NuGet package dependencies and keep your dependencies up to date
+
+### GitHub Package Registry
+
+- **[Consuming GitHub Packages](.github/CONSUMING-GITHUB-PACKAGES.md)** - Using packages from GitHub Package Registry for testing pre-release versions
+
+### Building Packages
+
+- **[CreateNuGetPackages Script Documentation](.github/CreateNuGetPackages-Documentation.md)** - Detailed guide for building and publishing NuGet packages, including the automated package creation process
+
+---
+
+## Workflow Documentation
+
+Documentation related to GitHub Actions workflows and automation:
+
+### PR Build Workflow
+
+- **[PR Workflow](.github/PR-WORKFLOW.md)** - Automated build and testing process for pull requests, including package validation
+
+---
+
+## Technical References
+
+Technical documentation for specific issues and workarounds:
+
+### BlockList Label Workaround
+
+- **[BlockList Label Workaround](.github/BLOCKLIST-LABEL-WORKAROUND.md)** - Documentation for the temporary workaround for Umbraco BlockList label export issue (#20801)
+
+### Removing Workarounds
+
+- **[Removal Guide](.github/REMOVAL-GUIDE.md)** - Instructions for removing the BlockList label workaround when Umbraco fixes the underlying issue
+
+---
+
+## Additional Resources
+
+### External Resources
+
+- **GitHub Repository**: [https://github.com/prjseal/Clean](https://github.com/prjseal/Clean)
+- **Issues and Bug Reports**: [GitHub Issues](https://github.com/prjseal/Clean/issues)
+- **NuGet Package**: [https://www.nuget.org/packages/Clean](https://www.nuget.org/packages/Clean)
+
+### Headless Frontend Example
+
+- **[Clean Starter Kit Headless Frontend](https://github.com/hifi-phil/clean-headless)** by Phil Whittaker - Complete Next.js frontend implementation
+
+### Legacy Versions
+
+- **[Clean Starter Kit for Umbraco v9](https://github.com/prjseal/Clean-Starter-Kit-for-Umbraco-v9)** - For Umbraco versions 9-12
+
+---
+
+## Need Help?
+
+If you can't find what you're looking for in the documentation:
+
+1. Check the [GitHub Issues](https://github.com/prjseal/Clean/issues) to see if your question has been answered
+2. Search the existing documentation using your browser's find function (Ctrl+F / Cmd+F)
+3. Create a new issue with the `question` label if you need further assistance
+
+---
+
+## Contributing to Documentation
+
+Found an error or want to improve the documentation? Contributions are welcome! Please see the [Contributing Guide](.github/CONTRIBUTING.md) for information on how to submit documentation improvements.
+
+---
+
+**Last Updated**: 2025-11-26

--- a/README.md
+++ b/README.md
@@ -293,19 +293,7 @@ After installation, you'll need to:
 
 ## Documentation
 
-This project includes comprehensive documentation to help you work with the Clean starter kit:
-
-### For Contributors and Developers
-
-- **[Contributing Guide](.github/CONTRIBUTING.md)** - How to contribute to the project, code standards, and testing requirements
-- **[PR Workflow](.github/PR-WORKFLOW.md)** - Guidelines for creating and reviewing pull requests
-- **[Versioning and Releases](.github/VERSIONING-AND-RELEASES.md)** - Understanding version numbers and release processes
-
-### Package Management
-
-- **[Update NuGet Packages](.github/UPDATE-NUGET-PACKAGES.md)** - How to update project NuGet package dependencies
-- **[Consuming GitHub Packages](.github/CONSUMING-GITHUB-PACKAGES.md)** - Using packages from GitHub Package Registry
-- **[CreateNuGetPackages Script Documentation](.github/CreateNuGetPackages-Documentation.md)** - Detailed guide for building and publishing NuGet packages
+For detailed documentation about this package and the repository, please see the [docs](DOCUMENTATION.md).
 
 ---
 


### PR DESCRIPTION
Created a new DOCUMENTATION.md file that serves as a comprehensive index to all documentation resources in the repository. This improves discoverability and organization of documentation.

Changes:
- Created DOCUMENTATION.md with organized sections for:
  - Getting Started
  - For Contributors and Developers
  - Package Management
  - Workflow Documentation
  - Technical References
- Included links to all 8 markdown files in .github folder:
  - CONTRIBUTING.md
  - PR-WORKFLOW.md
  - VERSIONING-AND-RELEASES.md
  - UPDATE-NUGET-PACKAGES.md
  - CONSUMING-GITHUB-PACKAGES.md
  - CreateNuGetPackages-Documentation.md
  - BLOCKLIST-LABEL-WORKAROUND.md
  - REMOVAL-GUIDE.md
- Updated README.md Documentation section to link to the new docs index
- Simplified README by moving detailed documentation links to dedicated file

Benefits:
- Single source of truth for all documentation
- Better organization and categorization
- Easier to maintain and update
- Improved user experience when searching for specific guides