### PR TITLE
docs: Add documentation for release workflow and scripts

### DIFF
--- a/.github/script-add-release-assets.md
+++ b/.github/script-add-release-assets.md
@@ -1,0 +1,59 @@
+# Add Release Assets Script
+
+## Overview
+
+This script uploads NuGet packages to GitHub release assets using the GitHub CLI.
+
+## Script Location
+
+`.github/workflows/powershell/Add-ReleaseAssets.ps1`
+
+## Purpose
+
+Attaches .nupkg files to the GitHub release for download alongside the release notes.
+
+## When It's Used
+
+- **Release Workflow**: After packages are published to NuGet.org
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `ReleaseTag` | string | Yes | - | The GitHub release tag to upload assets to |
+| `PackagesPath` | string | No | `.artifacts/nuget` | Path to directory containing .nupkg files |
+
+## What It Does
+
+1. **Finds Packages** - Gets all .nupkg files from artifacts
+2. **Uploads Each** - Uses `gh release upload` with `--clobber`
+3. **Reports Status** - Shows success/warning for each package
+
+## Output
+
+```
+================================================
+Uploading packages to GitHub Release
+================================================
+Uploading Clean.Core.7.0.0.nupkg...
+✅ Uploaded Clean.Core.7.0.0.nupkg
+
+Uploading Clean.7.0.0.nupkg...
+✅ Uploaded Clean.7.0.0.nupkg
+```
+
+## Usage Examples
+
+```powershell
+.\Add-ReleaseAssets.ps1 -ReleaseTag "v7.0.0"
+```
+
+## Related Documentation
+
+- [workflow-versioning-releases.md](workflow-versioning-releases.md) - Parent workflow
+
+## Notes
+
+- Uses **--clobber** to replace existing assets
+- **Non-failing** - warnings only
+- Requires **GITHUB_TOKEN** with release write permissions

--- a/.github/script-create-nuget-packages.md
+++ b/.github/script-create-nuget-packages.md
@@ -1,0 +1,97 @@
+# Create NuGet Packages Script
+
+## Overview
+
+This comprehensive script creates NuGet packages by starting Umbraco, downloading the package via API, applying BlockList label fixes (temporary workaround), updating .csproj versions, and building all packages in dependency order.
+
+## Script Location
+
+`.github/workflows/powershell/CreateNuGetPackages.ps1`
+
+## Purpose
+
+Orchestrates the entire package creation process including running Umbraco, downloading content package, fixing BlockList labels, updating versions, and building all NuGet packages.
+
+## When It's Used
+
+- **Release Workflow**: Main package creation step after README updates
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `Version` | string | Yes | The version number for the packages |
+
+## What It Does
+
+1. **Stops Running Processes** - Kills any Umbraco processes
+2. **Configures NuGet Sources** - Detects all configured sources
+3. **Restores Solution** - Explicitly restores with all sources
+4. **Starts Umbraco** - Runs Clean.Blog project
+5. **Waits for API** - Polls until Umbraco responds
+6. **Downloads Package** - Gets package.zip via API
+7. **Fixes BlockList Labels** - Applies workaround for Umbraco issue #20801
+8. **Updates Versions** - Sets version in all .csproj files
+9. **Builds Packages** - In dependency order: Core → Headless → Clean → Template
+
+## Key Features
+
+### BlockList Label Fix (Temporary)
+
+Workaround for [Umbraco issue #20801](https://github.com/umbraco/Umbraco-CMS/issues/20801):
+- Extracts package.zip
+- Reads BlockList config from uSync
+- Adds labels to package.xml
+- Repacks package.zip
+
+### Dependency Order Building
+
+1. **Clean.Core** - Base package
+2. **Clean.Headless** - Depends on Core
+3. **Clean** - Depends on Core and Headless
+4. **template-pack** - Template package
+
+Uses local NuGet source to avoid NU1102 errors.
+
+### Version Updates
+
+Updates in .csproj files:
+- `<Version>` or `<PackageVersion>`
+- `<InformationalVersion>` (base version without suffix)
+- `<AssemblyVersion>` (base version without suffix)
+- `<PackageReference>` for Clean.* packages
+
+## Output
+
+Packages created in `.artifacts/nuget/`:
+- Clean.Core.{version}.nupkg
+- Clean.Headless.{version}.nupkg
+- Clean.{version}.nupkg
+- Umbraco.Community.Templates.Clean.{version}.nupkg
+
+## Troubleshooting
+
+### Issue: Umbraco Fails to Start
+
+**Solution**: Check logs, increase timeout, verify configuration
+
+### Issue: API Authentication Fails
+
+**Solution**: Verify client ID/secret in appsettings
+
+### Issue: Build Fails with NU1102
+
+**Solution**: Ensure dependency order is correct, local source is configured
+
+## Related Documentation
+
+- [workflow-versioning-releases.md](workflow-versioning-releases.md) - Parent workflow
+- BlockList issue: https://github.com/umbraco/Umbraco-CMS/issues/20801
+
+## Notes
+
+- **Most complex script** in the workflow (831 lines)
+- **Temporary BlockList fix** - remove when Umbraco fixes issue
+- **Builds in dependency order** to avoid package resolution errors
+- **Uses local NuGet source** for intermediate packages
+- **Supports both PowerShell 5.x and Core 6+**

--- a/.github/script-extract-release-version.md
+++ b/.github/script-extract-release-version.md
@@ -1,0 +1,239 @@
+# Extract Release Version Script
+
+## Overview
+
+This script extracts and validates version information from a GitHub release tag, ensuring it follows semantic versioning format.
+
+## Script Location
+
+`.github/workflows/powershell/Extract-ReleaseVersion.ps1`
+
+## Purpose
+
+Parses the GitHub release tag, removes version prefix, validates format, and outputs version information for use in subsequent workflow steps.
+
+## When It's Used
+
+- **Release Workflow**: First step after release is published to extract version from tag
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `ReleaseTag` | string | Yes | The GitHub release tag (e.g., v7.0.0 or 7.0.0) |
+| `IsPrerelease` | string | Yes | Boolean string indicating if this is a prerelease |
+
+## How It Works
+
+```mermaid
+flowchart TD
+    Start([Script Start]) --> Display[Display Release Tag]
+    Display --> RemovePrefix[Remove 'v' Prefix<br/>v7.0.0 → 7.0.0]
+    RemovePrefix --> Validate{Valid SemVer<br/>Format?}
+
+    Validate -->|No| Error[Display Error<br/>Exit Code 1]
+    Error --> End1([Exit: Failure])
+
+    Validate -->|Yes| DisplayVersion[Display Version<br/>Green color]
+    DisplayVersion --> DisplayPrerelease[Display Prerelease Status]
+    DisplayPrerelease --> SetOutput[Set GITHUB_OUTPUT:<br/>version<br/>is_prerelease]
+    SetOutput --> End2([Exit: Success])
+
+    style Error fill:#ffcccc
+    style DisplayVersion fill:#ccffcc
+    style Validate fill:#e6e6fa
+```
+
+## What It Does
+
+1. **Tag Display**
+   - Shows the release tag as provided
+
+2. **Prefix Removal**
+   - Removes leading 'v' if present
+   - `v7.0.0` becomes `7.0.0`
+   - `7.0.0` stays `7.0.0`
+
+3. **Version Validation**
+   - Checks against SemVer pattern
+   - Valid: `X.Y.Z` or `X.Y.Z-prerelease`
+   - Invalid: `X.Y.Z.W` or other formats
+
+4. **Output Generation**
+   - Sets `version` output variable
+   - Sets `is_prerelease` output variable
+
+## Output
+
+### Console Output
+
+**Valid Version**:
+```
+Release tag: v7.0.0
+Release version: 7.0.0
+Is prerelease: false
+```
+
+**Valid Prerelease**:
+```
+Release tag: v7.0.0-rc.1
+Release version: 7.0.0-rc.1
+Is prerelease: true
+```
+
+**Invalid Version**:
+```
+Release tag: 7.0.0.1
+::error::Invalid version format: 7.0.0.1. Expected format: X.Y.Z or X.Y.Z-prerelease
+```
+
+### GitHub Actions Output
+
+```
+version=7.0.0
+is_prerelease=false
+```
+
+## Usage Examples
+
+### Example 1: Stable Release
+
+```powershell
+.\Extract-ReleaseVersion.ps1 `
+  -ReleaseTag "v7.0.0" `
+  -IsPrerelease "false"
+```
+
+### Example 2: Prerelease
+
+```powershell
+.\Extract-ReleaseVersion.ps1 `
+  -ReleaseTag "v7.0.0-rc.1" `
+  -IsPrerelease "true"
+```
+
+### Example 3: In Workflow
+
+```yaml
+- name: Extract version from release tag
+  id: version
+  shell: pwsh
+  run: |
+    ./.github/workflows/powershell/Extract-ReleaseVersion.ps1 `
+      -ReleaseTag "${{ github.event.release.tag_name }}" `
+      -IsPrerelease "${{ github.event.release.prerelease }}"
+```
+
+## Implementation Details
+
+### Regex Pattern
+
+```powershell
+'^\d+\.\d+\.\d+(-[a-zA-Z0-9\.\-]+)?$'
+```
+
+**Breakdown**:
+- `^\d+\.\d+\.\d+`: Three numeric segments separated by dots
+- `(-[a-zA-Z0-9\.\-]+)?`: Optional prerelease suffix after hyphen
+- `$`: End of string
+
+**Matches**:
+- ✅ `7.0.0`
+- ✅ `7.0.0-rc.1`
+- ✅ `7.0.0-beta.2`
+- ✅ `7.0.0-alpha`
+- ❌ `7.0.0.1` (4 segments)
+- ❌ `v7.0.0` (prefix not removed yet)
+- ❌ `7.0` (only 2 segments)
+
+### Prefix Removal
+
+```powershell
+$version = $ReleaseTag -replace '^v', ''
+```
+
+Removes only leading 'v', case-sensitive.
+
+### Error Handling
+
+**GitHub Actions error annotation**:
+```powershell
+Write-Host "::error::Invalid version format: $version..." -ForegroundColor Red
+exit 1
+```
+
+Shows error in workflow UI with annotation.
+
+## Validation Rules
+
+### Semantic Versioning 2.0
+
+**Required Format**: `MAJOR.MINOR.PATCH[-PRERELEASE]`
+
+**Examples**:
+- Stable: `7.0.0`, `7.1.2`, `8.0.0`
+- Prerelease: `7.0.0-rc.1`, `7.0.0-beta.2`, `7.0.0-alpha`
+
+**Prerelease Identifiers**:
+- Alphanumeric with dots and hyphens
+- Examples: `rc.1`, `beta.2`, `alpha`, `preview-1`
+
+## Troubleshooting
+
+### Issue: Invalid Version Format Error
+
+**Symptoms**:
+```
+::error::Invalid version format: 7.0.0.1
+```
+
+**Cause**:
+- Four-segment version number
+- Non-SemVer format
+
+**Solution**:
+Use three-segment SemVer:
+```
+v7.0.0     ✅
+v7.0.0.1   ❌
+```
+
+### Issue: Version with 'v' Prefix in Output
+
+**Symptoms**:
+Output contains `v7.0.0` instead of `7.0.0`.
+
+**Cause**:
+- Script should remove it - this would be a bug
+
+**Solution**:
+- Check script logic
+- Ensure `-replace '^v', ''` is working
+
+### Issue: Prerelease Not Detected
+
+**Symptoms**:
+`is_prerelease=false` for an RC release.
+
+**Cause**:
+- Parameter passed from GitHub event might be wrong
+
+**Solution**:
+Check GitHub event prerelease flag:
+```yaml
+IsPrerelease: "${{ github.event.release.prerelease }}"
+```
+
+## Related Documentation
+
+- [workflow-versioning-releases.md](workflow-versioning-releases.md) - Parent workflow
+- [script-show-version-info.md](script-show-version-info.md) - Next step in workflow
+
+## Notes
+
+- **Validates SemVer format** according to Semantic Versioning 2.0
+- **Fails workflow** on invalid version format
+- **Removes 'v' prefix** for consistency
+- **Passes through prerelease flag** from GitHub event
+- **Sets output variables** for subsequent steps
+- **Uses GitHub Actions annotations** for errors

--- a/.github/script-new-version-update-pull-request.md
+++ b/.github/script-new-version-update-pull-request.md
@@ -1,0 +1,98 @@
+# New Version Update Pull Request Script
+
+## Overview
+
+This script creates a pull request to merge version updates back to the main branch after a release.
+
+## Script Location
+
+`.github/workflows/powershell/New-VersionUpdatePullRequest.ps1`
+
+## Purpose
+
+Automates PR creation for version bumps in .csproj and README files, ensuring main branch stays up-to-date with release versions.
+
+## When It's Used
+
+- **Release Workflow**: After packages are uploaded to release assets
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `Version` | string | Yes | The version number being released |
+| `IsPrerelease` | string | Yes | Boolean string indicating if this is a prerelease |
+| `ReleaseUrl` | string | Yes | URL to the GitHub release |
+
+## What It Does
+
+1. **Configures Git** - Sets github-actions[bot] as committer
+2. **Checks for Changes** - Exits if no changes to commit
+3. **Creates Branch** - `release/update-versions-{version}`
+4. **Stages Files** - All .csproj and README files
+5. **Commits** - With `[skip ci]` flag
+6. **Pushes Branch** - To remote
+7. **Creates PR** - With detailed description
+
+## Output
+
+```
+================================================
+Creating PR with Version Updates
+================================================
+Fetching main branch...
+
+Modified files:
+ M Clean/Clean.csproj
+ M README.md
+
+Creating branch: release/update-versions-7.0.0
+Staging .csproj files...
+Staging README.md file...
+Committing changes with message: chore: Update versions to 7.0.0 [skip ci]
+Pushing branch to origin...
+✅ Successfully pushed branch release/update-versions-7.0.0
+
+Creating pull request...
+✅ Successfully created pull request
+================================================
+```
+
+## PR Description Format
+
+```markdown
+## Summary
+This PR updates version references in the codebase following the release of version 7.0.0.
+
+## Changes
+- Updated version references in .csproj files
+- Updated README.md with the latest version information
+- Updated Umbraco marketplace README files with the latest version information
+
+## Additional Info
+- Release: [https://github.com/...](https://github.com/...)
+- Prerelease: false
+
+---
+*This PR was automatically created by the release workflow.*
+```
+
+## Usage Examples
+
+```powershell
+.\New-VersionUpdatePullRequest.ps1 `
+  -Version "7.0.0" `
+  -IsPrerelease "false" `
+  -ReleaseUrl "https://github.com/prjseal/Clean/releases/tag/v7.0.0"
+```
+
+## Related Documentation
+
+- [workflow-versioning-releases.md](workflow-versioning-releases.md) - Parent workflow
+
+## Notes
+
+- Creates **automatic PR** for version updates
+- Uses **[skip ci]** to avoid circular workflows
+- **Bot identity** for commits
+- **Exits gracefully** if no changes

--- a/.github/script-publish-to-nuget.md
+++ b/.github/script-publish-to-nuget.md
@@ -1,0 +1,81 @@
+# Publish to NuGet Script
+
+## Overview
+
+This script publishes all NuGet packages from the artifacts directory to NuGet.org with comprehensive error handling and reporting.
+
+## Script Location
+
+`.github/workflows/powershell/Publish-ToNuGet.ps1`
+
+## Purpose
+
+Publishes Clean packages to NuGet.org for public consumption, with validation and failure tracking.
+
+## When It's Used
+
+- **Release Workflow**: After packages are created and uploaded as artifacts
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `ApiKey` | string | Yes | - | The NuGet API key for authentication |
+| `PackagesPath` | string | No | `.artifacts/nuget` | Path to directory containing .nupkg files |
+
+## What It Does
+
+1. **API Key Validation** - Verifies API key is set
+2. **Package Discovery** - Finds all .nupkg files
+3. **Package Publishing** - Pushes each to NuGet.org with `--skip-duplicate`
+4. **Failure Tracking** - Tracks which packages fail
+5. **Error Reporting** - Fails workflow if any package fails
+
+## Output
+
+```
+================================================
+Publishing NuGet Packages to NuGet.org
+================================================
+Found 4 package(s) to publish:
+  - Clean.Core.7.0.0.nupkg
+  - Clean.Headless.7.0.0.nupkg
+  - Clean.7.0.0.nupkg
+  - Umbraco.Community.Templates.Clean.7.0.0.nupkg
+
+Publishing Clean.Core.7.0.0.nupkg to NuGet.org...
+✅ Successfully published Clean.Core.7.0.0.nupkg
+
+================================================
+Package Publishing Complete
+================================================
+✅ All packages published successfully!
+```
+
+## Usage Examples
+
+```powershell
+.\Publish-ToNuGet.ps1 -ApiKey $env:NUGET_API_KEY
+```
+
+## Troubleshooting
+
+### Issue: API Key Not Set
+
+**Solution**: Add NUGET_API_KEY to repository secrets
+
+### Issue: Package Already Exists
+
+**Solution**: Use --skip-duplicate (already included)
+
+## Related Documentation
+
+- [workflow-versioning-releases.md](workflow-versioning-releases.md) - Parent workflow
+- [script-create-nuget-packages.md](script-create-nuget-packages.md) - Package creation
+
+## Notes
+
+- **Fails workflow** if any package fails to publish
+- **Uses --skip-duplicate** to handle existing versions
+- **Tracks failures** and reports at end
+- **Provides setup instructions** if API key missing

--- a/.github/script-show-release-summary.md
+++ b/.github/script-show-release-summary.md
@@ -1,0 +1,77 @@
+# Show Release Summary Script
+
+## Overview
+
+This script displays a comprehensive summary of the release including version, published packages, and links.
+
+## Script Location
+
+`.github/workflows/powershell/Show-ReleaseSummary.ps1`
+
+## Purpose
+
+Provides a final formatted summary of the release process for workflow logs.
+
+## When It's Used
+
+- **Release Workflow**: Final step (runs even if previous steps fail with `if: always()`)
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `Version` | string | Yes | - | The version number that was released |
+| `ReleaseTag` | string | Yes | - | The GitHub release tag |
+| `IsPrerelease` | string | Yes | - | Boolean string indicating if prerelease |
+| `ReleaseUrl` | string | Yes | - | URL to the GitHub release |
+| `PackagesPath` | string | No | `.artifacts/nuget` | Path to packages directory |
+
+## What It Does
+
+1. **Displays Header** - Green formatted banner
+2. **Shows Version Info** - Version, tag, prerelease status, URL
+3. **Lists Packages** - All published packages with NuGet.org links
+
+## Output
+
+```
+================================================
+Release Summary
+================================================
+Version: 7.0.0
+Release Tag: v7.0.0
+Prerelease: false
+Release URL: https://github.com/prjseal/Clean/releases/tag/v7.0.0
+================================================
+
+Published Packages:
+  - Clean.Core.7.0.0.nupkg
+    https://www.nuget.org/packages/Clean/7.0.0
+  - Clean.Headless.7.0.0.nupkg
+    https://www.nuget.org/packages/Clean/7.0.0
+  - Clean.7.0.0.nupkg
+    https://www.nuget.org/packages/Clean/7.0.0
+  - Umbraco.Community.Templates.Clean.7.0.0.nupkg
+    https://www.nuget.org/packages/Clean/7.0.0
+```
+
+## Usage Examples
+
+```powershell
+.\Show-ReleaseSummary.ps1 `
+  -Version "7.0.0" `
+  -ReleaseTag "v7.0.0" `
+  -IsPrerelease "false" `
+  -ReleaseUrl "https://github.com/prjseal/Clean/releases/tag/v7.0.0"
+```
+
+## Related Documentation
+
+- [workflow-versioning-releases.md](workflow-versioning-releases.md) - Parent workflow
+
+## Notes
+
+- **Always runs** via `if: always()`
+- **Informational only** - no actions taken
+- Provides **quick links** to NuGet.org packages
+- **Green color** for success indication

--- a/.github/script-show-version-info.md
+++ b/.github/script-show-version-info.md
@@ -1,0 +1,112 @@
+# Show Version Info Script
+
+## Overview
+
+This simple script displays release version information in a formatted, visually appealing way for workflow logs.
+
+## Script Location
+
+`.github/workflows/powershell/Show-VersionInfo.ps1`
+
+## Purpose
+
+Outputs formatted version information including release tag, version number, prerelease status, and release name for easy visibility in workflow logs.
+
+## When It's Used
+
+- **Release Workflow**: Immediately after version extraction to display version info
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `ReleaseTag` | string | Yes | The GitHub release tag |
+| `Version` | string | Yes | The extracted version number |
+| `IsPrerelease` | string | Yes | Boolean string indicating if this is a prerelease |
+| `ReleaseName` | string | Yes | The name of the GitHub release |
+
+## How It Works
+
+```mermaid
+flowchart TD
+    Start([Script Start]) --> Header[Display Cyan Header<br/>Release Version Information]
+    Header --> ShowTag[Display Release Tag<br/>Green color]
+    ShowTag --> ShowVersion[Display Version<br/>Yellow color]
+    ShowVersion --> ShowPrerelease[Display Prerelease Status<br/>Yellow color]
+    ShowPrerelease --> ShowName[Display Release Name<br/>Green color]
+    ShowName --> Footer[Display Cyan Footer]
+    Footer --> End([Exit: Success])
+
+    style Header fill:#cceeff
+    style ShowTag fill:#ccffcc
+    style ShowVersion fill:#ffffcc
+    style ShowPrerelease fill:#ffffcc
+    style ShowName fill:#ccffcc
+    style Footer fill:#cceeff
+```
+
+## What It Does
+
+Displays formatted version information with color coding for easy reading in workflow logs.
+
+## Output
+
+### Console Output
+
+```
+================================================
+Release Version Information
+================================================
+Release Tag: v7.0.0
+Version: 7.0.0
+Prerelease: false
+Release Name: Version 7.0.0
+================================================
+```
+
+## Usage Examples
+
+### Example 1: Stable Release
+
+```powershell
+.\Show-VersionInfo.ps1 `
+  -ReleaseTag "v7.0.0" `
+  -Version "7.0.0" `
+  -IsPrerelease "false" `
+  -ReleaseName "Version 7.0.0"
+```
+
+### Example 2: Prerelease
+
+```powershell
+.\Show-VersionInfo.ps1 `
+  -ReleaseTag "v7.0.0-rc.1" `
+  -Version "7.0.0-rc.1" `
+  -IsPrerelease "true" `
+  -ReleaseName "Version 7.0.0 RC1"
+```
+
+### Example 3: In Workflow
+
+```yaml
+- name: Display version info
+  shell: pwsh
+  run: |
+    ./.github/workflows/powershell/Show-VersionInfo.ps1 `
+      -ReleaseTag "${{ github.event.release.tag_name }}" `
+      -Version "${{ steps.version.outputs.version }}" `
+      -IsPrerelease "${{ steps.version.outputs.is_prerelease }}" `
+      -ReleaseName "${{ github.event.release.name }}"
+```
+
+## Related Documentation
+
+- [workflow-versioning-releases.md](workflow-versioning-releases.md) - Parent workflow
+- [script-extract-release-version.md](script-extract-release-version.md) - Previous step
+
+## Notes
+
+- **Informational only** - no actions taken
+- **Color-coded output** for readability
+- **Always succeeds** (no error conditions)
+- Helps **workflow runners** quickly see release info

--- a/.github/script-update-readme-versions.md
+++ b/.github/script-update-readme-versions.md
@@ -1,0 +1,277 @@
+# Update README Versions Script
+
+## Overview
+
+This script updates README files with the latest Clean and Umbraco version information following a release, mapping Clean versions to appropriate Umbraco versions.
+
+## Script Location
+
+`.github/workflows/powershell/Update-ReadmeVersions.ps1`
+
+## Purpose
+
+Updates installation commands in README files with the correct Clean package version and corresponding Umbraco version for the appropriate Umbraco major version section.
+
+## When It's Used
+
+- **Release Workflow**: After version extraction, before building packages
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `Version` | string | Yes | The Clean package version (e.g., 7.0.0 or 7.0.0-rc1) |
+
+## How It Works
+
+```mermaid
+flowchart TD
+    Start([Script Start]) --> DisplayHeader[Display Header]
+    DisplayHeader --> ParseMajor[Extract Clean Major Version<br/>7.0.0 → 7]
+    ParseMajor --> MapVersion{Version<br/>in Map?}
+
+    MapVersion -->|No| ExitNoMap[Exit: No mapping found]
+    ExitNoMap --> End1([Exit: Success])
+
+    MapVersion -->|Yes| ShowMapping[Display Mapping<br/>Clean X.x → Umbraco Y.x]
+    ShowMapping --> ReadCsproj[Read Clean.csproj<br/>Extract Umbraco version]
+
+    ReadCsproj --> LoopREADME[For Each README File]
+    LoopREADME --> FindSection{Find Umbraco<br/>Section?}
+
+    FindSection -->|No| WarnNoSection[Warn: Section not found]
+    FindSection -->|Yes| UpdateSection[Update Section:<br/>- Umbraco.Templates<br/>- Clean version<br/>- Clean.Core version<br/>- Template version]
+
+    WarnNoSection --> MoreFiles{More<br/>Files?}
+    UpdateSection --> SaveFile[Save README if changed]
+    SaveFile --> DisplaySuccess[✅ Display Updates]
+    DisplaySuccess --> MoreFiles
+
+    MoreFiles -->|Yes| LoopREADME
+    MoreFiles -->|No| DisplayFooter[Display Footer]
+    DisplayFooter --> End2([Exit: Success])
+
+    style ExitNoMap fill:#ffffcc
+    style WarnNoSection fill:#ffffcc
+    style DisplaySuccess fill:#ccffcc
+    style MapVersion fill:#e6e6fa
+    style FindSection fill:#e6e6fa
+    style MoreFiles fill:#e6e6fa
+```
+
+## What It Does
+
+1. **Version Mapping**
+   - Extracts Clean major version
+   - Maps to Umbraco major version:
+     - Clean 4.x → Umbraco 13
+     - Clean 7.x → Umbraco 17
+   - Exits gracefully if no mapping exists
+
+2. **Umbraco Version Detection**
+   - Reads `template/Clean/Clean.csproj`
+   - Extracts Umbraco.Cms.Web.Website version
+
+3. **README Updates**
+   - Finds appropriate Umbraco section (`## Umbraco 13` or `## Umbraco 17`)
+   - Updates installation commands:
+     - `dotnet new install Umbraco.Templates::{version}`
+     - `dotnet add package Clean --version {version}`
+     - `dotnet add package Clean.Core --version {version}`
+     - `dotnet new install Umbraco.Community.Templates.Clean::{version}`
+
+4. **Multiple Files**
+   - Updates `README.md`
+   - Updates `umbraco-marketplace-readme.md`
+   - Updates `umbraco-marketplace-readme-clean.md`
+
+## Output
+
+### Console Output
+
+```
+================================================
+Updating README Files with Latest Versions
+================================================
+Clean version: 7.0.0
+Mapped Clean 7.x -> Umbraco 17.x
+
+Reading Umbraco version from template/Clean/Clean.csproj...
+Found Umbraco version: 17.0.1
+
+Updating README.md...
+✅ Updated README.md
+   - Umbraco.Templates: 17.0.1
+   - Clean: 7.0.0
+   - Clean.Core: 7.0.0
+   - Umbraco.Community.Templates.Clean: 7.0.0
+
+Updating umbraco-marketplace-readme.md...
+✅ Updated umbraco-marketplace-readme.md
+   - Umbraco.Templates: 17.0.1
+   - Clean: 7.0.0
+   - Clean.Core: 7.0.0
+   - Umbraco.Community.Templates.Clean: 7.0.0
+
+================================================
+README files updated successfully
+================================================
+```
+
+## Usage Examples
+
+### Example 1: Clean 7.x Release
+
+```powershell
+.\Update-ReadmeVersions.ps1 -Version "7.0.0"
+```
+
+Updates Umbraco 17 section in all README files.
+
+### Example 2: Clean 4.x Release
+
+```powershell
+.\Update-ReadmeVersions.ps1 -Version "4.2.1"
+```
+
+Updates Umbraco 13 section in all README files.
+
+### Example 3: Prerelease
+
+```powershell
+.\Update-ReadmeVersions.ps1 -Version "7.0.0-rc.1"
+```
+
+Updates with prerelease version.
+
+### Example 4: In Workflow
+
+```yaml
+- name: Update README files with latest versions
+  shell: pwsh
+  run: |
+    ./.github/workflows/powershell/Update-ReadmeVersions.ps1 `
+      -Version "${{ steps.version.outputs.version }}"
+```
+
+## Implementation Details
+
+### Version Mapping
+
+```powershell
+$umbracoMajorMap = @{
+    4 = 13
+    7 = 17
+}
+```
+
+**Why only 4 and 7?**
+- Clean v5 (Umbraco 15) and v6 (Umbraco 16) are no longer maintained
+- Only actively supported versions have mappings
+
+### Regex Pattern for Sections
+
+```powershell
+"(?ms)$umbracoSectionHeader.*?(?=(^## |\z))"
+```
+
+**Breakdown**:
+- `(?ms)`: Multiline + dotall mode
+- `$umbracoSectionHeader`: Start marker (e.g., "## Umbraco 17")
+- `.*?`: Content (non-greedy)
+- `(?=(^## |\z))`: Lookahead for next section or end of file
+
+### Update Patterns
+
+**Umbraco.Templates**:
+```powershell
+-replace "dotnet new install Umbraco\.Templates::\S+",
+         "dotnet new install Umbraco.Templates::$umbracoVersion"
+```
+
+**Clean Package**:
+```powershell
+-replace "(dotnet add .* package Clean --version )\S+",
+         "`${1}$cleanVersion"
+```
+
+**Clean Template**:
+```powershell
+-replace "dotnet new install Umbraco\.Community\.Templates\.Clean::\S+",
+         "dotnet new install Umbraco.Community.Templates.Clean::$cleanVersion"
+```
+
+### Error Handling
+
+Script uses `try-catch` to handle errors gracefully:
+- Continues workflow on error
+- Displays warnings
+- Doesn't fail release process
+
+## Files Modified
+
+1. **README.md** - Main repository README
+2. **umbraco-marketplace-readme.md** - Umbraco marketplace listing
+3. **umbraco-marketplace-readme-clean.md** - Clean-specific marketplace README
+
+## Troubleshooting
+
+### Issue: Section Not Found
+
+**Symptoms**:
+```
+⚠️  Could not find section '## Umbraco 17' in README.md
+```
+
+**Cause**:
+- README doesn't have section for this Umbraco version
+- Section header format differs
+
+**Solution**:
+- Add appropriate section to README
+- Ensure header matches exactly: `## Umbraco {major}`
+
+### Issue: No Mapping Found
+
+**Symptoms**:
+```
+⚠️  No Umbraco version mapping found for Clean 5.x
+```
+
+**Cause**:
+- Releasing Clean version without mapping
+- Version 5 and 6 are no longer maintained
+
+**Solution**:
+- Normal for unmaintained versions
+- Add mapping if supporting new version
+
+### Issue: Umbraco Version Not Found
+
+**Symptoms**:
+```
+⚠️  Could not find Umbraco.Cms.Web.Website PackageReference
+```
+
+**Cause**:
+- Clean.csproj structure changed
+- File path incorrect
+
+**Solution**:
+- Verify `template/Clean/Clean.csproj` exists
+- Check PackageReference format
+
+## Related Documentation
+
+- [workflow-versioning-releases.md](workflow-versioning-releases.md) - Parent workflow
+- [script-extract-release-version.md](script-extract-release-version.md) - Version extraction
+
+## Notes
+
+- Updates **installation commands** in README files
+- Maps **Clean versions to Umbraco versions**
+- **Non-failing** - warnings only on error
+- Updates **multiple README files** in single pass
+- **Preserves formatting** - only updates version numbers
+- **Section-specific** - updates only relevant Umbraco major version section
+- **Regex-based** - flexible pattern matching for version updates

--- a/.github/workflow-versioning-releases.md
+++ b/.github/workflow-versioning-releases.md
@@ -540,3 +540,56 @@ v7.1.0-rc.2
 - [GitHub Releases Documentation](https://docs.github.com/en/repositories/releasing-projects-on-github)
 - [Consuming GitHub Packages](general-consuming-packages.md)
 - [Umbraco Version Support](https://umbraco.com/products/knowledge-center/long-term-support-and-end-of-life/)
+
+## Workflow Steps
+
+The release workflow is triggered when a GitHub release is published and performs the following sequence:
+
+```mermaid
+flowchart TD
+    Start([GitHub Release Published]) --> Checkout[1. Checkout Repository<br/>Fetch full git history]
+    Checkout --> DotNet[2. Setup .NET 10<br/>Install .NET 10 SDK]
+    
+    DotNet --> ExtractVersion[3. Extract Release Version<br/>Parse tag, validate SemVer<br/>Remove 'v' prefix]
+    ExtractVersion --> ShowVersion[4. Display Version Info<br/>Show tag, version, prerelease status]
+    
+    ShowVersion --> UpdateREADME[5. Update README Files<br/>Map Clean version to Umbraco<br/>Update installation commands]
+    
+    UpdateREADME --> CreatePackages[6. Create NuGet Packages<br/>Start Umbraco<br/>Download package via API<br/>Fix BlockList labels<br/>Update .csproj versions<br/>Build in dependency order]
+    
+    CreatePackages --> UploadArtifacts[7. Upload Package Artifacts<br/>Save .nupkg files to workflow]
+    
+    UploadArtifacts --> PublishNuGet[8. Publish to NuGet.org<br/>Push all packages<br/>Track failures]
+    
+    PublishNuGet --> PublishSuccess{All Packages<br/>Published?}
+    PublishSuccess -->|No| End1([End: Publish Failed])
+    
+    PublishSuccess -->|Yes| AddAssets[9. Add Packages to Release<br/>Upload .nupkg to GitHub release]
+    
+    AddAssets --> CreatePR[10. Create Version Update PR<br/>Commit .csproj and README changes<br/>Create PR to main]
+    
+    CreatePR --> Summary[11. Release Summary<br/>Display version, packages, links<br/>Always runs]
+    
+    Summary --> End2([End: Success])
+    
+    style End1 fill:#ffcccc
+    style Summary fill:#ccffcc
+    style End2 fill:#ccffcc
+    style PublishSuccess fill:#e6e6fa
+```
+
+## Scripts Used
+
+The release workflow uses the following PowerShell scripts:
+
+| Script | Purpose | Documentation |
+|--------|---------|---------------|
+| Extract-ReleaseVersion.ps1 | Extracts and validates version from release tag | [Link](script-extract-release-version.md) |
+| Show-VersionInfo.ps1 | Displays formatted version information | [Link](script-show-version-info.md) |
+| Update-ReadmeVersions.ps1 | Updates README files with version info | [Link](script-update-readme-versions.md) |
+| CreateNuGetPackages.ps1 | Creates all NuGet packages | [Link](script-create-nuget-packages.md) |
+| Publish-ToNuGet.ps1 | Publishes packages to NuGet.org | [Link](script-publish-to-nuget.md) |
+| Add-ReleaseAssets.ps1 | Uploads packages to GitHub release | [Link](script-add-release-assets.md) |
+| New-VersionUpdatePullRequest.ps1 | Creates PR with version updates | [Link](script-new-version-update-pull-request.md) |
+| Show-ReleaseSummary.ps1 | Displays final release summary | [Link](script-show-release-summary.md) |
+


### PR DESCRIPTION
- Update workflow-versioning-releases.md with comprehensive workflow diagram
- Add Scripts Used section with links to all script documentation
- Create script documentation for all 8 release workflow PowerShell scripts:
  - Extract-ReleaseVersion.ps1
  - Show-VersionInfo.ps1
  - Update-ReadmeVersions.ps1
  - CreateNuGetPackages.ps1
  - Publish-ToNuGet.ps1
  - Add-ReleaseAssets.ps1
  - New-VersionUpdatePullRequest.ps1
  - Show-ReleaseSummary.ps1

Each script documentation includes:
- Overview and purpose
- Parameters and usage examples
- Process flow diagrams using Mermaid (where applicable)
- Implementation details
- Troubleshooting guidance
- Links to related documentation

Follows same format and structure as update packages workflow documentation.