### PR TITLE
docs: Add comprehensive cross-linking between all documentation files

### DIFF
--- a/.github/clean-documentation.md
+++ b/.github/clean-documentation.md
@@ -19,8 +19,8 @@ Welcome to the comprehensive documentation for the Clean Starter Kit for Umbraco
 
 New to Clean Starter Kit? Start with these essential guides:
 
-- **[README](README.md)** - Installation instructions, features overview, and quick start guide
-- **[Package Architecture](.github/clean-packages.md)** - Understanding the NuGet packages, dependencies, and migration path
+- **[README](../README.md)** - Installation instructions, features overview, and quick start guide
+- **[Package Architecture](clean-packages.md)** - Understanding the NuGet packages, dependencies, and migration path
 
 ---
 
@@ -28,7 +28,7 @@ New to Clean Starter Kit? Start with these essential guides:
 
 Documentation for using Clean as a headless CMS with API endpoints:
 
-- **[Headless/API Implementation](.github/clean-headless-api.md)** - Delivery API setup, Next.js revalidation configuration, API endpoints, and Swagger documentation
+- **[Headless/API Implementation](clean-headless-api.md)** - Delivery API setup, Next.js revalidation configuration, API endpoints, and Swagger documentation
 
 ---
 
@@ -38,15 +38,15 @@ Documentation for those who want to contribute to the Clean Starter Kit project:
 
 ### Contributing
 
-- **[Contributing Guide](.github/general-contributing.md)** - Code standards, testing requirements, and how to submit contributions to the project
+- **[Contributing Guide](general-contributing.md)** - Code standards, testing requirements, and how to submit contributions to the project
 
 ### Pull Requests
 
-- **[PR Workflow](.github/workflow-pr.md)** - Guidelines for creating and reviewing pull requests, including automated workflows and testing procedures
+- **[PR Workflow](workflow-pr.md)** - Guidelines for creating and reviewing pull requests, including automated workflows and testing procedures
 
 ### Versioning and Releases
 
-- **[Versioning and Releases](.github/workflow-versioning-releases.md)** - Understanding version numbers, release processes, and how Clean versions map to Umbraco versions
+- **[Versioning and Releases](workflow-versioning-releases.md)** - Understanding version numbers, release processes, and how Clean versions map to Umbraco versions
 
 ---
 
@@ -56,15 +56,15 @@ Documentation for managing NuGet packages and dependencies:
 
 ### Updating Dependencies
 
-- **[Update NuGet Packages](.github/script-update-packages.md)** - How to update project NuGet package dependencies and keep your dependencies up to date
+- **[Update NuGet Packages](script-update-packages.md)** - How to update project NuGet package dependencies and keep your dependencies up to date
 
 ### GitHub Package Registry
 
-- **[Consuming GitHub Packages](.github/general-consuming-packages.md)** - Using packages from GitHub Package Registry for testing pre-release versions
+- **[Consuming GitHub Packages](general-consuming-packages.md)** - Using packages from GitHub Package Registry for testing pre-release versions
 
 ### Building Packages
 
-- **[CreateNuGetPackages Script Documentation](.github/script-create-packages.md)** - Detailed guide for building and publishing NuGet packages, including the automated package creation process
+- **[CreateNuGetPackages Script Documentation](script-create-packages.md)** - Detailed guide for building and publishing NuGet packages, including the automated package creation process
 
 ---
 
@@ -74,7 +74,15 @@ Documentation related to GitHub Actions workflows and automation:
 
 ### PR Build Workflow
 
-- **[PR Workflow](.github/workflow-pr.md)** - Automated build and testing process for pull requests, including package validation
+- **[PR Workflow](workflow-pr.md)** - Automated build and testing process for pull requests, including package validation
+
+### Update Packages Workflow
+
+- **[Update NuGet Packages](workflow-update-nuget-packages.md)** - Automated workflow for updating NuGet packages and Umbraco versions
+
+### Release Workflow
+
+- **[Versioning and Releases](workflow-versioning-releases.md)** - Understanding version numbers, release processes, and how Clean versions map to Umbraco versions
 
 ---
 
@@ -84,7 +92,7 @@ Technical documentation for specific issues and workarounds:
 
 ### BlockList Label Workaround
 
-- **[BlockList Label Workaround](.github/clean-blocklist-workaround.md)** - Documentation for the temporary workaround for Umbraco BlockList label export issue (#20801)
+- **[BlockList Label Workaround](clean-blocklist-workaround.md)** - Documentation for the temporary workaround for Umbraco BlockList label export issue (#20801)
 
 ---
 
@@ -118,7 +126,7 @@ If you can't find what you're looking for in the documentation:
 
 ## Contributing to Documentation
 
-Found an error or want to improve the documentation? Contributions are welcome! Please see the [Contributing Guide](.github/general-contributing.md) for information on how to submit documentation improvements.
+Found an error or want to improve the documentation? Contributions are welcome! Please see the [Contributing Guide](general-contributing.md) for information on how to submit documentation improvements.
 
 ---
 

--- a/.github/clean-headless-api.md
+++ b/.github/clean-headless-api.md
@@ -57,3 +57,12 @@ Explore and test the API endpoints using the built-in Swagger UI:
 **URL**: `/umbraco/swagger/index.html?urls.primaryName=Clean%20starter%20kit`
 
 This provides interactive documentation for all available API endpoints, including request/response schemas and the ability to test endpoints directly from the browser.
+
+---
+
+## Related Documentation
+
+- [README](../README.md) - Installation instructions and features overview
+- [Package Architecture](clean-packages.md) - Understanding the Clean.Headless package
+- [Clean Documentation](clean-documentation.md) - Comprehensive documentation index
+- [Contributing Guide](general-contributing.md) - Guidelines for contributing API improvements

--- a/.github/clean-packages.md
+++ b/.github/clean-packages.md
@@ -95,3 +95,14 @@ The recommended workflow is:
 2. **First Run**: Run the project, publish content, save dictionary items
 3. **Switch Packages**: Change from `Clean` to `Clean.Core` to protect your customizations
 4. **Future Updates**: Continue using `Clean.Core` for updates without losing customizations
+
+---
+
+## Related Documentation
+
+- [README](../README.md) - Installation instructions and quick start guide
+- [Headless/API Implementation](clean-headless-api.md) - Information about Clean.Headless package features
+- [Clean Documentation](clean-documentation.md) - Comprehensive documentation index
+- [Contributing Guide](general-contributing.md) - Guidelines for contributing to the packages
+- [Consuming GitHub Packages](general-consuming-packages.md) - Using development versions of packages
+- [PR Workflow](workflow-pr.md) - How packages are built and tested in CI/CD

--- a/.github/general-consuming-packages.md
+++ b/.github/general-consuming-packages.md
@@ -162,6 +162,13 @@ On some systems, you may need to specify the protocol version:
 
 GitHub Packages are public for public repositories, but authentication is still required to consume them. This is a GitHub limitation, not specific to this package.
 
+## Related Documentation
+
+- [PR Workflow](workflow-pr.md) - Explains when and how development packages are published
+- [Contributing Guide](general-contributing.md) - Guidelines for contributing to the project
+- [Package Architecture](clean-packages.md) - Understanding the different NuGet packages
+- [Clean Documentation](clean-documentation.md) - Comprehensive documentation index
+
 ## Questions or Issues?
 
 If you encounter problems consuming packages from GitHub Packages, please open an issue at:

--- a/.github/general-contributing.md
+++ b/.github/general-contributing.md
@@ -397,6 +397,15 @@ When contributing:
 - [Umbraco Content Delivery API](https://docs.umbraco.com/umbraco-cms/reference/content-delivery-api)
 - [uSync Documentation](https://docs.jumoo.co.uk/usync/)
 
+### Project Documentation
+
+- [Clean Documentation](clean-documentation.md) - Comprehensive documentation index
+- [PR Workflow](workflow-pr.md) - Automated PR build and testing process
+- [Release Workflow](workflow-versioning-releases.md) - Version management and releases
+- [Update Packages Workflow](workflow-update-nuget-packages.md) - Automated dependency updates
+- [Package Architecture](clean-packages.md) - Understanding the NuGet packages
+- [Consuming GitHub Packages](general-consuming-packages.md) - Using development packages
+
 ### Project Links
 
 - [GitHub Repository](https://github.com/prjseal/Clean)

--- a/.github/workflow-pr.md
+++ b/.github/workflow-pr.md
@@ -421,7 +421,9 @@ Each major step displays:
 ## Related Documentation
 
 - [workflow-versioning-releases.md](workflow-versioning-releases.md) - Release process and version strategy
+- [workflow-update-nuget-packages.md](workflow-update-nuget-packages.md) - Automated package updates
 - [general-consuming-packages.md](general-consuming-packages.md) - How to consume development packages
+- [general-contributing.md](general-contributing.md) - Contributing guidelines and development workflow
 - [README.md](../README.md) - Project overview and installation
 
 ## Differences from Release Workflow

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ For detailed information about the package architecture and the different NuGet 
 
 For detailed documentation about this package and the repository, please see the [docs](.github/clean-documentation.md).
 
+### GitHub Workflows and Automation
+
+The project uses automated workflows for continuous integration and deployment:
+
+- **[PR Build Workflow](.github/workflow-pr.md)** - Automated testing and package publishing for pull requests
+- **[Release Workflow](.github/workflow-versioning-releases.md)** - Automated release process and version management
+- **[Update Packages Workflow](.github/workflow-update-nuget-packages.md)** - Automated dependency updates
+
 ## Installation
 
 ### Prerequisites


### PR DESCRIPTION
This commit improves documentation navigation by adding missing cross-references:

- Added workflow documentation links to README.md
- Fixed incorrect relative paths in clean-documentation.md (README.md paths)
- Added missing Update Packages workflow link in clean-documentation.md
- Reorganized workflow documentation section with all three workflows
- Added related documentation sections to:
  - workflow-pr.md (update packages, contributing)
  - general-contributing.md (all workflow and package docs)
  - general-consuming-packages.md (PR workflow, package architecture)
  - clean-headless-api.md (README, package architecture, contributing)
  - clean-packages.md (README, headless API, workflows, consuming packages)

All documentation files are now properly interconnected for easy navigation.