### PR TITLE
Add GitHub Action to test latest Umbraco and Clean packages from NuGet

### DIFF
--- a/.github/workflows/test-umbraco-latest.yml
+++ b/.github/workflows/test-umbraco-latest.yml
@@ -1,0 +1,212 @@
+name: Test Umbraco with Latest Clean Package
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run every Monday at 9:00 AM UTC
+    - cron: '0 9 * * 1'
+
+jobs:
+  test-latest-packages:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Get latest Umbraco version
+        id: umbraco-version
+        shell: pwsh
+        run: |
+          Write-Host "Fetching latest Umbraco.Cms version from NuGet..." -ForegroundColor Yellow
+          $response = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/umbraco.cms/index.json"
+          $latestVersion = $response.versions | Where-Object { $_ -notmatch '-' } | Select-Object -Last 1
+          Write-Host "Latest Umbraco version: $latestVersion" -ForegroundColor Green
+          echo "version=$latestVersion" >> $env:GITHUB_OUTPUT
+
+      - name: Get latest Clean package version
+        id: clean-version
+        shell: pwsh
+        run: |
+          Write-Host "Fetching latest Clean package version from NuGet..." -ForegroundColor Yellow
+          $response = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/clean/index.json"
+          $latestVersion = $response.versions | Where-Object { $_ -notmatch '-' } | Select-Object -Last 1
+          Write-Host "Latest Clean version: $latestVersion" -ForegroundColor Green
+          echo "version=$latestVersion" >> $env:GITHUB_OUTPUT
+
+      - name: Create test directory
+        shell: pwsh
+        run: |
+          $testDir = "${{ github.workspace }}\test-latest"
+          if (Test-Path $testDir) {
+            Remove-Item $testDir -Recurse -Force
+          }
+          New-Item -ItemType Directory -Path $testDir | Out-Null
+          Write-Host "Created test directory: $testDir" -ForegroundColor Green
+
+      - name: Install Umbraco templates
+        shell: pwsh
+        run: |
+          Write-Host "Installing Umbraco templates version ${{ steps.umbraco-version.outputs.version }}..." -ForegroundColor Yellow
+          dotnet new install Umbraco.Templates@${{ steps.umbraco-version.outputs.version }} --force
+
+      - name: Create Umbraco project
+        shell: pwsh
+        working-directory: test-latest
+        run: |
+          Write-Host "Creating Umbraco project..." -ForegroundColor Yellow
+          dotnet new sln --name "TestLatestSolution"
+          dotnet new umbraco --force -n "TestLatestProject" --friendly-name "Administrator" --email "admin@example.com" --password "1234567890" --development-database-type SQLite
+          dotnet sln add "TestLatestProject"
+          Write-Host "Umbraco project created successfully" -ForegroundColor Green
+
+      - name: Install Clean package from NuGet
+        shell: pwsh
+        working-directory: test-latest
+        run: |
+          Write-Host "Installing Clean package version ${{ steps.clean-version.outputs.version }} from NuGet..." -ForegroundColor Yellow
+          dotnet add "TestLatestProject" package Clean --version ${{ steps.clean-version.outputs.version }}
+          Write-Host "Clean package installed successfully" -ForegroundColor Green
+
+      - name: Start Umbraco site
+        id: start-site
+        shell: pwsh
+        working-directory: test-latest
+        run: |
+          Write-Host "Starting Umbraco site..." -ForegroundColor Yellow
+          $logFile = "${{ github.workspace }}\test-latest\site.log"
+          $errFile = "${{ github.workspace }}\test-latest\site.err"
+
+          $process = Start-Process -FilePath "dotnet" `
+            -ArgumentList "run --project TestLatestProject" `
+            -RedirectStandardOutput $logFile `
+            -RedirectStandardError $errFile `
+            -NoNewWindow `
+            -PassThru
+
+          Write-Host "Site process started with PID: $($process.Id)" -ForegroundColor Green
+
+          # Wait for site to start and extract URL
+          $startTime = Get-Date
+          $timeoutSeconds = 180
+          $siteStarted = $false
+          $siteUrl = $null
+
+          Write-Host "Waiting for site to start (timeout: ${timeoutSeconds}s)..." -ForegroundColor Yellow
+
+          while (-not $siteStarted) {
+            if ((Get-Date) - $startTime -gt (New-TimeSpan -Seconds $timeoutSeconds)) {
+              Write-Host "Timeout reached! Site failed to start." -ForegroundColor Red
+              if (-not $process.HasExited) {
+                Stop-Process -Id $process.Id -Force
+              }
+              # Output logs for debugging
+              if (Test-Path $logFile) {
+                Write-Host "`nSite output log:" -ForegroundColor Yellow
+                Get-Content $logFile
+              }
+              if (Test-Path $errFile) {
+                Write-Host "`nSite error log:" -ForegroundColor Yellow
+                Get-Content $errFile
+              }
+              exit 1
+            }
+
+            if (Test-Path $logFile) {
+              $logContent = Get-Content $logFile -Raw
+
+              # Check if site is listening on HTTPS
+              if ($logContent -match "Now listening on:\s*(https://[^\s]+)") {
+                $siteUrl = $matches[1]
+                $siteStarted = $true
+                Write-Host "Site is running at: $siteUrl" -ForegroundColor Green
+                echo "url=$siteUrl" >> $env:GITHUB_OUTPUT
+                echo "pid=$($process.Id)" >> $env:GITHUB_OUTPUT
+                break
+              }
+            }
+
+            Start-Sleep -Seconds 2
+          }
+
+      - name: Install Playwright
+        shell: pwsh
+        working-directory: test-latest
+        run: |
+          Write-Host "Installing Playwright..." -ForegroundColor Yellow
+          npm init -y
+          npm install --save-dev playwright
+
+      - name: Install Playwright browsers
+        shell: pwsh
+        working-directory: test-latest
+        run: |
+          Write-Host "Installing Playwright browsers..." -ForegroundColor Yellow
+          npx playwright install chromium
+
+      - name: Create Playwright test script
+        shell: pwsh
+        working-directory: test-latest
+        run: |
+          Write-Host "Creating Playwright test script..." -ForegroundColor Yellow
+          & "${{ github.workspace }}\.github\workflows\powershell\Write-PlaywrightTestScript.ps1" -OutputPath "${{ github.workspace }}\test-latest\test.js"
+
+      - name: Run Playwright tests
+        shell: pwsh
+        working-directory: test-latest
+        env:
+          SITE_URL: ${{ steps.start-site.outputs.url }}
+        run: |
+          Write-Host "Running Playwright tests..." -ForegroundColor Yellow
+          node test.js
+          Write-Host "Playwright tests completed successfully" -ForegroundColor Green
+
+      - name: Stop Umbraco site
+        if: always()
+        shell: pwsh
+        run: |
+          $pid = "${{ steps.start-site.outputs.pid }}"
+          if ($pid) {
+            Write-Host "Stopping site process (PID: $pid)..." -ForegroundColor Yellow
+            try {
+              $process = Get-Process -Id $pid -ErrorAction SilentlyContinue
+              if ($process -and -not $process.HasExited) {
+                Stop-Process -Id $pid -Force
+                Write-Host "Site process stopped" -ForegroundColor Green
+              }
+            } catch {
+              Write-Host "Process already stopped or not found" -ForegroundColor Yellow
+            }
+          }
+
+      - name: Upload Screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: umbraco-latest-screenshots-${{ steps.umbraco-version.outputs.version }}-clean-${{ steps.clean-version.outputs.version }}
+          path: test-latest/screenshots/*.png
+          if-no-files-found: warn
+
+      - name: Test Summary
+        if: always()
+        shell: pwsh
+        run: |
+          Write-Host "`n================================================" -ForegroundColor Cyan
+          Write-Host "Test Summary" -ForegroundColor Cyan
+          Write-Host "================================================" -ForegroundColor Cyan
+          Write-Host "Umbraco Version: ${{ steps.umbraco-version.outputs.version }}" -ForegroundColor Green
+          Write-Host "Clean Package Version: ${{ steps.clean-version.outputs.version }}" -ForegroundColor Green
+          Write-Host "Screenshots uploaded as artifacts" -ForegroundColor Green
+          Write-Host "================================================" -ForegroundColor Cyan


### PR DESCRIPTION
This workflow automatically tests the latest published versions of the Clean package with the latest Umbraco version from NuGet.org. It includes:

- Automatic detection of latest stable versions from NuGet
- Umbraco project creation with the latest templates
- Clean package installation from NuGet
- Playwright tests to navigate pages and capture screenshots
- Screenshot upload as workflow artifacts
- Can be triggered manually or runs on schedule (weekly)