### PR TITLE
Rename test umbraco workflow to follow naming convention

### DIFF
--- a/.github/workflow-test-umbraco-latest.md
+++ b/.github/workflow-test-umbraco-latest.md
@@ -1,4 +1,4 @@
-# Test Umbraco with Latest Clean Package Workflow Documentation
+# Scheduled - Test Umbraco with Latest Clean Package Workflow Documentation
 
 This document describes the automated testing workflow that validates the Clean package with various versions of Umbraco from different sources, ensuring compatibility and functionality.
 
@@ -23,7 +23,7 @@ The workflow triggers in two ways:
 
 ### 1. Manual Trigger (workflow_dispatch)
 
-Navigate to **Actions** tab → Select **"Test Umbraco with Latest Clean Package"** → Click **"Run workflow"**
+Navigate to **Actions** tab → Select **"Scheduled - Test Umbraco with Latest Clean Package"** → Click **"Run workflow"**
 
 Configure test parameters:
 - **Package source**: Choose between `nuget` or `github-packages`

--- a/.github/workflows/test-umbraco-latest.yml
+++ b/.github/workflows/test-umbraco-latest.yml
@@ -1,4 +1,4 @@
-name: Test Umbraco with Latest Clean Package
+name: Scheduled - Test Umbraco with Latest Clean Package
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Updated the workflow display name from "Test Umbraco with Latest Clean Package"
to "Scheduled - Test Umbraco with Latest Clean Package" to follow the same naming
convention as other workflows in the repository.

Changes:
- Updated workflow display name in test-umbraco-latest.yml
- Updated workflow documentation title and references in workflow-test-umbraco-latest.md

This aligns with the naming pattern used by other workflows:
- "Scheduled - Update NuGet Packages"
- "PR - Build NuGet Packages"
- "Release - Publish to NuGet.org"
- "Cleanup - GitHub Packages CI Versions"