### PR TITLE
Add Umbraco content tree navigation and screenshots to test script

### DIFF
--- a/.github/workflows/powershell/Write-PlaywrightTestScript.ps1
+++ b/.github/workflows/powershell/Write-PlaywrightTestScript.ps1
@@ -101,6 +101,164 @@ const path = require('path');
       fullPage: true
     });
     console.log('Screenshot saved: umbraco-login.png');
+    counter++;
+
+    // Log into Umbraco
+    console.log('Logging into Umbraco...');
+    await page.fill('input[name="username"]', 'admin@example.com');
+    await page.fill('input[name="password"]', '1234567890');
+    await page.click('button[type="submit"]');
+
+    // Wait for navigation after login
+    await page.waitForLoadState('networkidle', { timeout: 30000 });
+    await page.waitForTimeout(3000);
+
+    // Take screenshot after login
+    await page.screenshot({
+      path: path.join(screenshotsDir, counter.toString().padStart(2, '0') + '-umbraco-logged-in.png'),
+      fullPage: true
+    });
+    console.log('Screenshot saved: umbraco-logged-in.png');
+    counter++;
+
+    // Navigate to Content section
+    console.log('Navigating to Content section...');
+
+    // Wait for and click on Content section
+    const contentSelector = 'a[href="#/content"], [data-element="section-content"], a[title="Content"]';
+    await page.waitForSelector(contentSelector, { timeout: 10000 });
+    await page.click(contentSelector);
+    await page.waitForTimeout(2000);
+
+    // Function to click on a tree item and take screenshot
+    async function clickTreeItemAndScreenshot(itemName, screenshotCounter) {
+      try {
+        console.log(`Clicking on tree item: ${itemName}...`);
+
+        // Try multiple selectors for tree items
+        const treeItemSelectors = [
+          `[data-element="tree-item-${itemName}"]`,
+          `a[title="${itemName}"]`,
+          `.umb-tree-item:has-text("${itemName}")`,
+          `text=${itemName}`
+        ];
+
+        let clicked = false;
+        for (const selector of treeItemSelectors) {
+          try {
+            await page.click(selector, { timeout: 5000 });
+            clicked = true;
+            break;
+          } catch (e) {
+            // Try next selector
+            continue;
+          }
+        }
+
+        if (!clicked) {
+          console.log(`Could not find tree item: ${itemName}, trying alternative approach...`);
+          // Try to find and click by text content
+          const elements = await page.$$('a, button, div[role="button"]');
+          for (const element of elements) {
+            const text = await element.textContent();
+            if (text && text.trim().toLowerCase() === itemName.toLowerCase()) {
+              await element.click();
+              clicked = true;
+              break;
+            }
+          }
+        }
+
+        if (!clicked) {
+          console.log(`Warning: Could not click on ${itemName}`);
+          return screenshotCounter;
+        }
+
+        // Wait 5 seconds before taking screenshot
+        console.log(`Waiting 5 seconds before taking screenshot...`);
+        await page.waitForTimeout(5000);
+
+        // Take screenshot
+        const screenshotName = screenshotCounter.toString().padStart(2, '0') +
+          `-content-${itemName.replace(/[^a-z0-9]/gi, '-').toLowerCase()}.png`;
+        await page.screenshot({
+          path: path.join(screenshotsDir, screenshotName),
+          fullPage: true
+        });
+        console.log(`Screenshot saved: ${screenshotName}`);
+        return screenshotCounter + 1;
+      } catch (error) {
+        console.error(`Error processing ${itemName}:`, error.message);
+        return screenshotCounter;
+      }
+    }
+
+    // Click on Home page first
+    counter = await clickTreeItemAndScreenshot('Home', counter);
+
+    // Try to expand the Home node to see child pages
+    console.log('Attempting to expand Home node...');
+    try {
+      // Look for expand/collapse buttons near Home
+      const expandSelectors = [
+        '[data-element="tree-item-Home"] button[aria-label*="expand"]',
+        '[data-element="tree-item-Home"] .umb-tree-item__expand',
+        '[title="Home"] ~ button',
+        '.umb-tree-item:has-text("Home") button.umb-tree-item__expand'
+      ];
+
+      let expanded = false;
+      for (const selector of expandSelectors) {
+        try {
+          await page.click(selector, { timeout: 3000 });
+          expanded = true;
+          console.log('Home node expanded');
+          await page.waitForTimeout(1000);
+          break;
+        } catch (e) {
+          continue;
+        }
+      }
+
+      if (!expanded) {
+        // Alternative: double-click on Home might expand it
+        console.log('Trying double-click to expand...');
+        try {
+          await page.dblclick('text=Home', { timeout: 3000 });
+          await page.waitForTimeout(1000);
+        } catch (e) {
+          console.log('Could not expand Home node automatically');
+        }
+      }
+
+      // Get all visible tree items that are children of Home
+      console.log('Looking for child pages under Home...');
+      const childPages = await page.evaluate(() => {
+        const items = [];
+        // Try to find child tree items
+        const treeItems = document.querySelectorAll('.umb-tree-item, [class*="tree-item"]');
+        treeItems.forEach(item => {
+          const text = item.textContent.trim();
+          // Exclude Home itself and empty items
+          if (text && text !== 'Home' && text.length > 0 && text.length < 100) {
+            items.push(text);
+          }
+        });
+        return items;
+      });
+
+      console.log(`Found ${childPages.length} potential child pages`);
+
+      // Click on each child page
+      for (const pageName of childPages) {
+        if (pageName && pageName.trim()) {
+          counter = await clickTreeItemAndScreenshot(pageName.trim(), counter);
+        }
+      }
+
+    } catch (error) {
+      console.error('Error expanding or processing child pages:', error.message);
+    }
 
   } catch (error) {
     console.error('Error during testing:', error);


### PR DESCRIPTION
Updated the Playwright test script to navigate through the Umbraco content tree after login:
- Logs into Umbraco backoffice
- Navigates to Content section
- Clicks on Home page and takes screenshot after 5 seconds
- Expands the Home node to reveal child pages
- Clicks on each child page under Home and takes screenshot after 5 seconds wait
- Includes multiple fallback selectors for robustness across Umbraco versions