### PR TITLE
Fix empty IncludePrerelease parameter in PR creation step

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -143,11 +143,20 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           echo $env:GITHUB_TOKEN | gh auth login --with-token
+
+          # Determine the correct includePrerelease value based on trigger type
+          $isScheduled = '${{ github.event_name }}' -eq 'schedule'
+          if ($isScheduled) {
+            $includePrereleaseValue = '${{ env.SCHEDULED_INCLUDE_PRERELEASE }}'
+          } else {
+            $includePrereleaseValue = '${{ github.event.inputs.includePrerelease }}'
+          }
+
           ./.github/workflows/powershell/New-PackageUpdatePullRequest.ps1 `
             -ReadmeUpdated "${{ steps.update-readme.outputs.readme_updated }}" `
             -UpdatedVersions "${{ steps.update-readme.outputs.updated_versions }}" `
             -PackageSummary "${{ steps.read-summary.outputs.summary }}" `
-            -IncludePrerelease "${{ github.event.inputs.includePrerelease }}" `
+            -IncludePrerelease "$includePrereleaseValue" `
             -NuGetSources "${{ github.event.inputs.nugetSources }}" `
             -BranchName "${{ steps.commit-and-push.outputs.branchName }}" `
             -WorkspacePath "${{ github.workspace }}"


### PR DESCRIPTION
The workflow was failing when triggered by schedule because
github.event.inputs.includePrerelease is undefined/empty for
scheduled runs, causing an empty string to be passed to the
PowerShell script.

Now the workflow determines the correct value based on the
trigger type, using SCHEDULED_INCLUDE_PRERELEASE for scheduled
runs and the input value for manual runs.