### PR TITLE
Fix: Prevent workflow from attempting to create branch/PR when no packages to update

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -122,6 +122,7 @@ jobs:
 
       - name: Read package summary
         id: read-summary
+        if: ${{ github.event.inputs.dryRun != 'true' && steps.check-changes.outputs.has_changes == 'true' }}
         shell: pwsh
         run: |
           ./.github/workflows/powershell/Get-PackageSummary.ps1 -WorkspacePath "${{ github.workspace }}"


### PR DESCRIPTION
The 'Read package summary' step was running unconditionally, even when there were no changes. This could cause downstream steps to fail or behave unexpectedly.

Added conditional check to ensure this step only runs when there are actual changes to process, consistent with other post-check steps.