### PR TITLE
Fix: Use explicit if statement for boolean conversion

### DIFF
--- a/.github/workflows/powershell/Invoke-CommitAndPush.ps1
+++ b/.github/workflows/powershell/Invoke-CommitAndPush.ps1
@@ -43,8 +43,13 @@ param(
 )
 
 # Early exit: Check if there are actually any changes to commit
-# Explicitly convert string to boolean
-$readmeUpdated = [bool]($ReadmeUpdated -eq 'true')
+# Explicitly convert string to boolean using if statement to guarantee proper boolean type
+if ($ReadmeUpdated -eq 'true') {
+    $readmeUpdated = $true
+} else {
+    $readmeUpdated = $false
+}
+
 $summaryPath = "$WorkspacePath\.artifacts\package-summary.txt"
 $packagesUpdated = $false
 if (Test-Path $summaryPath) {

--- a/.github/workflows/powershell/New-PackageUpdatePullRequest.ps1
+++ b/.github/workflows/powershell/New-PackageUpdatePullRequest.ps1
@@ -58,8 +58,13 @@ param(
 $prBodyFile = "$WorkspacePath\.artifacts\pr-body.md"
 
 # Determine what was updated
-# Explicitly convert string to boolean
-$readmeUpdated = [bool]($ReadmeUpdated -eq 'true')
+# Explicitly convert string to boolean using if statement to guarantee proper boolean type
+if ($ReadmeUpdated -eq 'true') {
+    $readmeUpdated = $true
+} else {
+    $readmeUpdated = $false
+}
+
 $summaryContent = $PackageSummary
 $packagesUpdated = ($summaryContent -notmatch 'No package summary found') -and ($summaryContent -notmatch 'No packages to update')
 

--- a/.github/workflows/powershell/Test-WorkflowChanges.ps1
+++ b/.github/workflows/powershell/Test-WorkflowChanges.ps1
@@ -35,8 +35,12 @@ Write-Host "Checking for Workflow Changes" -ForegroundColor Cyan
 Write-Host "================================================" -ForegroundColor Cyan
 Write-Host "ReadmeUpdated input parameter: '$ReadmeUpdated'" -ForegroundColor Magenta
 
-# Explicitly convert string to boolean
-$readmeUpdated = [bool]($ReadmeUpdated -eq 'true')
+# Explicitly convert string to boolean using if statement to guarantee proper boolean type
+if ($ReadmeUpdated -eq 'true') {
+    $readmeUpdated = $true
+} else {
+    $readmeUpdated = $false
+}
 
 Write-Host "After conversion - ReadmeUpdated type: $($readmeUpdated.GetType().Name), value: $readmeUpdated" -ForegroundColor Magenta
 


### PR DESCRIPTION
CRITICAL FIX: The [bool] cast was not working correctly in PowerShell, still producing String types instead of Boolean.

Problem with previous approach:
- `$readmeUpdated = [bool]($ReadmeUpdated -eq 'true')` still resulted in String type
- This caused the condition check to fail
- Workflow incorrectly proceeded when no changes were made

New approach:
- Use explicit if/else statement to guarantee proper boolean type: ```powershell if ($ReadmeUpdated -eq 'true') { $readmeUpdated = $true } else { $readmeUpdated = $false } ```
- This ensures $readmeUpdated is ALWAYS a proper Boolean
- The condition `-not $readmeUpdated -and -not $packagesUpdated` will now work correctly

Applied to all three affected scripts:
- Test-WorkflowChanges.ps1
- Invoke-CommitAndPush.ps1
- New-PackageUpdatePullRequest.ps1

This will fix the workflow logic bug that caused branches and PRs to be created when no changes exist.