### PR TITLE
Fix: Use string comparison directly instead of boolean conversion

### DIFF
--- a/.github/workflows/powershell/Invoke-CommitAndPush.ps1
+++ b/.github/workflows/powershell/Invoke-CommitAndPush.ps1
@@ -43,13 +43,6 @@ param(
 )
 
 # Early exit: Check if there are actually any changes to commit
-# Explicitly convert string to boolean using if statement to guarantee proper boolean type
-if ($ReadmeUpdated -eq 'true') {
-    $readmeUpdated = $true
-} else {
-    $readmeUpdated = $false
-}
-
 $summaryPath = "$WorkspacePath\.artifacts\package-summary.txt"
 $packagesUpdated = $false
 if (Test-Path $summaryPath) {
@@ -57,9 +50,10 @@ if (Test-Path $summaryPath) {
     $packagesUpdated = $content -notmatch 'No packages to update'
 }
 
-Write-Host "Commit check - README updated: $readmeUpdated (type: $($readmeUpdated.GetType().Name)), Packages updated: $packagesUpdated"
+Write-Host "Commit check - README updated: $ReadmeUpdated (string), Packages updated: $packagesUpdated (boolean)"
 
-if (-not $readmeUpdated -and -not $packagesUpdated) {
+# Use string comparison for ReadmeUpdated to avoid boolean conversion issues
+if (($ReadmeUpdated -ne 'true') -and (-not $packagesUpdated)) {
     Write-Host "No changes detected (neither README nor packages updated). Exiting without creating branch." -ForegroundColor Yellow
     exit 0
 }
@@ -76,8 +70,8 @@ if (git diff --cached --quiet) {
     exit 0
 }
 
-# Create appropriate commit message
-if ($readmeUpdated -and -not $packagesUpdated) {
+# Create appropriate commit message - use string comparison for ReadmeUpdated
+if (($ReadmeUpdated -eq 'true') -and (-not $packagesUpdated)) {
     # Only README updated - skip CI builds
     $updatedVersions = $UpdatedVersions -split ',' | ForEach-Object { $_.Trim() }
     if ($updatedVersions.Count -eq 1) {
@@ -89,7 +83,7 @@ if ($readmeUpdated -and -not $packagesUpdated) {
     $commitMessage = "Update README with latest $versionText version [skip ci]"
     Write-Host "Only README updated - adding [skip ci] to commit message" -ForegroundColor Cyan
 }
-elseif (-not $readmeUpdated -and $packagesUpdated) {
+elseif (($ReadmeUpdated -ne 'true') -and $packagesUpdated) {
     # Only packages updated
     $commitMessage = "Update NuGet packages"
 }

--- a/.github/workflows/powershell/New-PackageUpdatePullRequest.ps1
+++ b/.github/workflows/powershell/New-PackageUpdatePullRequest.ps1
@@ -57,14 +57,7 @@ param(
 # Create PR body in a file to avoid escaping issues
 $prBodyFile = "$WorkspacePath\.artifacts\pr-body.md"
 
-# Determine what was updated
-# Explicitly convert string to boolean using if statement to guarantee proper boolean type
-if ($ReadmeUpdated -eq 'true') {
-    $readmeUpdated = $true
-} else {
-    $readmeUpdated = $false
-}
-
+# Determine what was updated - use string comparison for ReadmeUpdated
 $summaryContent = $PackageSummary
 $packagesUpdated = ($summaryContent -notmatch 'No package summary found') -and ($summaryContent -notmatch 'No packages to update')
 
@@ -72,7 +65,7 @@ $packagesUpdated = ($summaryContent -notmatch 'No package summary found') -and (
 "This PR updates the following:" | Out-File -FilePath $prBodyFile -Encoding UTF8
 "" | Out-File -FilePath $prBodyFile -Encoding UTF8 -Append
 
-if ($readmeUpdated) {
+if ($ReadmeUpdated -eq 'true') {
     $updatedVersions = $UpdatedVersions -split ',' | ForEach-Object { $_.Trim() }
     if ($updatedVersions.Count -eq 1) {
         $versionText = "Umbraco $($updatedVersions[0])"
@@ -142,7 +135,7 @@ $summary = @"
 ### 📋 Summary
 "@
 
-if ($readmeUpdated) {
+if ($ReadmeUpdated -eq 'true') {
     $summary += "`n- **README.md**: Updated with latest $versionText version"
 }
 if ($packagesUpdated) {

--- a/.github/workflows/powershell/Test-WorkflowChanges.ps1
+++ b/.github/workflows/powershell/Test-WorkflowChanges.ps1
@@ -35,15 +35,6 @@ Write-Host "Checking for Workflow Changes" -ForegroundColor Cyan
 Write-Host "================================================" -ForegroundColor Cyan
 Write-Host "ReadmeUpdated input parameter: '$ReadmeUpdated'" -ForegroundColor Magenta
 
-# Explicitly convert string to boolean using if statement to guarantee proper boolean type
-if ($ReadmeUpdated -eq 'true') {
-    $readmeUpdated = $true
-} else {
-    $readmeUpdated = $false
-}
-
-Write-Host "After conversion - ReadmeUpdated type: $($readmeUpdated.GetType().Name), value: $readmeUpdated" -ForegroundColor Magenta
-
 # Check if packages were updated by reading the summary file
 $summaryPath = "$WorkspacePath\.artifacts\package-summary.txt"
 $packagesUpdated = $false
@@ -57,19 +48,18 @@ else {
 }
 
 Write-Host ""
-Write-Host "README updated: $readmeUpdated" -ForegroundColor Yellow
-Write-Host "  Type: $($readmeUpdated.GetType().Name), Value: '$readmeUpdated'" -ForegroundColor Magenta
-Write-Host "Packages updated: $packagesUpdated" -ForegroundColor Yellow
-Write-Host "  Type: $($packagesUpdated.GetType().Name), Value: '$packagesUpdated'" -ForegroundColor Magenta
+Write-Host "README updated: $ReadmeUpdated (string)" -ForegroundColor Yellow
+Write-Host "Packages updated: $packagesUpdated (boolean)" -ForegroundColor Yellow
 Write-Host ""
 Write-Host "Condition evaluation:" -ForegroundColor Cyan
-Write-Host "  -not `$readmeUpdated = $(-not $readmeUpdated)" -ForegroundColor Magenta
-Write-Host "  -not `$packagesUpdated = $(-not $packagesUpdated)" -ForegroundColor Magenta
-Write-Host "  Combined: $(-not $readmeUpdated -and -not $packagesUpdated)" -ForegroundColor Magenta
+Write-Host "  ReadmeUpdated -ne 'true' = $($ReadmeUpdated -ne 'true')" -ForegroundColor Magenta
+Write-Host "  -not packagesUpdated = $(-not $packagesUpdated)" -ForegroundColor Magenta
+Write-Host "  Combined: $(($ReadmeUpdated -ne 'true') -and (-not $packagesUpdated))" -ForegroundColor Magenta
 Write-Host "================================================" -ForegroundColor Cyan
 Write-Host ""
 
-if (-not $readmeUpdated -and -not $packagesUpdated) {
+# Check both flags using string comparison for ReadmeUpdated
+if (($ReadmeUpdated -ne 'true') -and (-not $packagesUpdated)) {
     Write-Host "ENTERING: No changes block" -ForegroundColor Green
     Write-Host ""
     Write-Host "================================================" -ForegroundColor Green
@@ -111,7 +101,7 @@ else {
 
     # Add GitHub Action summary
     $changesList = @()
-    if ($readmeUpdated) { $changesList += "README updated" }
+    if ($ReadmeUpdated -eq 'true') { $changesList += "README updated" }
     if ($packagesUpdated) { $changesList += "NuGet packages updated" }
     $changesText = $changesList -join ", "
 


### PR DESCRIPTION
FINAL FIX: Completely bypass boolean conversion by using string comparison directly throughout.

The problem:
- PowerShell boolean conversion was mysteriously failing
- Even explicit if/else with $true/$false assignment resulted in String types
- This caused condition checks to fail

New approach:
- Work with $ReadmeUpdated as a STRING throughout
- Use string comparison in all conditions: $ReadmeUpdated -eq 'true' / $ReadmeUpdated -ne 'true'
- Only use boolean for $packagesUpdated (which works correctly)

Key changes:
- Test-WorkflowChanges.ps1: Changed condition to ($ReadmeUpdated -ne 'true') -and (-not $packagesUpdated)
- Invoke-CommitAndPush.ps1: Use string comparison in all $ReadmeUpdated checks
- New-PackageUpdatePullRequest.ps1: Use string comparison in all $ReadmeUpdated checks

This approach avoids the boolean conversion issue entirely by working with the data type we actually have (String) instead of fighting to convert it.