### PR TITLE
Restricts workflow runs to origin repository

### DIFF
--- a/.github/workflows/delete-issues-by-label.yml
+++ b/.github/workflows/delete-issues-by-label.yml
@@ -28,6 +28,7 @@ on:
 
 jobs:
   delete-issues:
+    if: github.repository == 'prjseal/Clean'
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/pr-build-packages.yml
+++ b/.github/workflows/pr-build-packages.yml
@@ -19,6 +19,7 @@ on:
 
 jobs:
   build-packages:
+    if: github.repository == 'prjseal/Clean'
     runs-on: windows-latest
     permissions:
       contents: read

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   publish-release:
+    if: github.repository == 'prjseal/Clean'
     runs-on: windows-latest
     permissions:
       contents: write       # Allow pushing branches and uploading release assets

--- a/.github/workflows/test-umbraco-latest-nightly.yml
+++ b/.github/workflows/test-umbraco-latest-nightly.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   test-latest-packages:
+    if: github.repository == 'prjseal/Clean'
     runs-on: windows-latest
     permissions:
       contents: read

--- a/.github/workflows/test-umbraco-latest-nuget.yml
+++ b/.github/workflows/test-umbraco-latest-nuget.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   test-latest-packages:
+    if: github.repository == 'prjseal/Clean'
     runs-on: windows-latest
     permissions:
       contents: read

--- a/.github/workflows/test-umbraco-latest.yml
+++ b/.github/workflows/test-umbraco-latest.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   test-latest-packages:
+    if: github.repository == 'prjseal/Clean'
     runs-on: windows-latest
     permissions:
       contents: read

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -31,7 +31,7 @@ env:
 jobs:
   update-packages:
     runs-on: windows-latest
-
+    if: github.repository == 'prjseal/Clean'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/zap-security-scan.yml
+++ b/.github/workflows/zap-security-scan.yml
@@ -28,6 +28,7 @@ jobs:
   zap-security-scan:
     # Only run on approved PR reviews or other triggers
     if: github.event_name != 'pull_request_review' || github.event.review.state == 'approved'
+    if: github.repository == 'prjseal/Clean'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Ensures that GitHub Actions workflows are only executed on the main repository, not on forks.