### PR TITLE
Fix duplicate if condition in ZAP security scan workflow

### DIFF
--- a/.github/workflows/zap-security-scan.yml
+++ b/.github/workflows/zap-security-scan.yml
@@ -26,9 +26,8 @@ on:
 
 jobs:
   zap-security-scan:
-    # Only run on approved PR reviews or other triggers
-    if: github.event_name != 'pull_request_review' || github.event.review.state == 'approved'
-    if: github.repository == 'prjseal/Clean'
+    # Only run on approved PR reviews or other triggers, and only in the origin repository
+    if: (github.event_name != 'pull_request_review' || github.event.review.state == 'approved') && github.repository == 'prjseal/Clean'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
- Combine two if conditions into single condition with && operator
- Ensures job only runs on approved PRs/other triggers AND in origin repo
- Fixes GitHub Actions validation error: 'if' is already defined