### PR TITLE
fix: Add SRI attributes to external font resources

### DIFF
--- a/template/Clean.Blog/Views/master.cshtml
+++ b/template/Clean.Blog/Views/master.cshtml
@@ -12,8 +12,8 @@
     <script defer src="https://use.fontawesome.com/releases/v6.5.1/js/all.js" crossorigin="anonymous" integrity="sha384-3ve3u7etWcm2heCe4TswfZSAYSg2jR/EJxRHuKM5foOiKS8IJL/xRlvmjCaHELBz"></script>
     <!-- Fonts - Using jsDelivr CDN with Subresource Integrity for security -->
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@fontsource/lora@@5.2.8/index.css" integrity="sha384-Wi45AXFnCt7CpP3/izQKYVS77fIXPkXRhQJUIv0ZB/KX9JioAPfErGpXHs9HFLgA" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@fontsource/open-sans@@5.2.7/index.css" integrity="sha384-QyAVq7f51nVaD35FlOq+sewmg4F/Rib4dfLdDuNIQWULRCBgde4wUV9bZ44nTdyS" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@fontsource/lora@@5.2.8/latin.css" integrity="sha384-f4M2zbjkXb09sOmEBQQr/7uaCoS42xKdzLA4btcuoodiBTSBt15fFwe57ZyRN5Zp" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@@fontsource/open-sans@@5.2.7/latin.css" integrity="sha384-qFkObpNRoSvQPhjjWheuOk1v30/JtCyeIlEa7UVNnbwCQtBJ9PthP7atExwLvrHu" crossorigin="anonymous">
     <!-- Core theme CSS (includes Bootstrap)-->
     <link href="/assets/css/styles.css" rel="stylesheet" asp-append-version="true" />
     <link href="/assets/css/vs2015.css" rel="stylesheet" asp-append-version="true" />


### PR DESCRIPTION
- Replace Google Fonts links with jsDelivr CDN (@fontsource packages)
- Add Subresource Integrity (SRI) hashes for font stylesheets
- Add proper crossorigin attributes for SRI validation
- Fix rel attribute (separate preconnect from stylesheet)

Resolves #388 - ZAP security scan issue for missing SRI attributes