### PR TITLE
fix: Update Content Security Policy to include additional script sources

### DIFF
--- a/template/Clean.Blog/Middleware/SecurityHeadersMiddleware.cs
+++ b/template/Clean.Blog/Middleware/SecurityHeadersMiddleware.cs
@@ -16,9 +16,9 @@ public class SecurityHeadersMiddleware
     // Default CSP policy suitable for Umbraco CMS
     private const string DefaultCspPolicy =
         "default-src 'self'; " +
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
-        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
-        "font-src 'self' data: https://fonts.gstatic.com; " +
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://use.fontawesome.com; " +
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; " +
+        "font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; " +
         "img-src 'self' data: https:; " +
         "connect-src 'self'; " +
         "frame-ancestors 'self'; " +


### PR DESCRIPTION
## Summary

Fixes the navbar menu toggle not working on mobile by updating the default Content Security Policy in `SecurityHeadersMiddleware.cs`.

The previous `DefaultCspPolicy` was missing CDN origins for Bootstrap and FontAwesome, causing the browser to silently block those scripts before they could load. Without Bootstrap JS, the `data-bs-toggle="collapse"` attribute on the navbar toggler was never initialised, so clicking the Menu button did nothing.

## Changes

**`template/Clean.Blog/Middleware/SecurityHeadersMiddleware.cs`**

| Directive | Before | After |
|---|---|---|
| `script-src` | `'self' 'unsafe-inline' 'unsafe-eval'` | + `https://cdn.jsdelivr.net` `https://use.fontawesome.com` |
| `style-src` | `'self' 'unsafe-inline' https://fonts.googleapis.com` | + `https://cdn.jsdelivr.net` |
| `font-src` | `'self' data: https://fonts.gstatic.com` | + `https://cdn.jsdelivr.net` |

- `https://cdn.jsdelivr.net` — required for Bootstrap JS bundle and jsDelivr
- `https://use.fontawesome.com` — required for FontAwesome JS (icon rendering)
- Google Fonts origins retained for backwards compatibility

## Notes

The SRI `integrity` attribute on the Bootstrap `<script>` tag does **not** bypass CSP. The browser enforces the CSP origin allowlist before attempting any download, so the script was being blocked before SRI could even run.
