### PR TITLE
Docs/delivery api setup

### DIFF
--- a/.github/clean-headless-api.md
+++ b/.github/clean-headless-api.md
@@ -16,6 +16,19 @@ The Clean starter kit includes full support for headless implementations. To ena
 }
 ```
 
+Update your `program.cs`:
+
+```csharp
+builder.CreateUmbracoBuilder()
+    .AddBackOffice()
+    .AddWebsite()
+    .AddDeliveryApi()
+    .AddComposers()
+    .Build();
+```
+
+Once the Content Delivery API is enabled, the next step is to rebuild the Delivery API content index **DeliveryApiContentIndex**. This can be done using the Examine Management dashboard in the Settings section of the Umbraco Backoffice.
+
 ## Next.js Revalidation
 
 To enable automatic revalidation of content in Next.js applications, configure the following in your `appsettings.json`:

--- a/template/Clean.Blog/Middleware/SecurityHeadersMiddleware.cs
+++ b/template/Clean.Blog/Middleware/SecurityHeadersMiddleware.cs
@@ -16,9 +16,9 @@ public class SecurityHeadersMiddleware
     // Default CSP policy suitable for Umbraco CMS
     private const string DefaultCspPolicy =
         "default-src 'self'; " +
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval'; " +
-        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
-        "font-src 'self' data: https://fonts.gstatic.com; " +
+        "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net https://use.fontawesome.com; " +
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://fonts.googleapis.com; " +
+        "font-src 'self' data: https://cdn.jsdelivr.net https://fonts.gstatic.com; " +
         "img-src 'self' data: https:; " +
         "connect-src 'self'; " +
         "frame-ancestors 'self'; " +


### PR DESCRIPTION
This pull request introduces improvements to the documentation for enabling the Content Delivery API and updates the Content Security Policy (CSP) in the middleware to support additional third-party resources. These changes help developers correctly configure their projects for headless implementations and ensure that required external assets load without CSP violations.

**Documentation updates:**

* Added instructions to update `program.cs` for enabling the Content Delivery API, and included guidance on rebuilding the Delivery API content index using the Examine Management dashboard. (.github/clean-headless-api.md)

**Security and configuration enhancements:**

* Expanded the default CSP in `SecurityHeadersMiddleware` to allow scripts, styles, and fonts from `cdn.jsdelivr.net` and `use.fontawesome.com`, ensuring compatibility with commonly used CDN-hosted assets. (template/Clean.Blog/Middleware/SecurityHeadersMiddleware.cs)