### PR TITLE
chore: Bump Umbraco and uSync NuGet packages to latest within v17

### DIFF
--- a/template/Clean.Blog/Clean.Blog.csproj
+++ b/template/Clean.Blog/Clean.Blog.csproj
@@ -7,13 +7,13 @@
     <!-- Disable compression. E.g. for umbraco backoffice files. These files should be precompressed by node and not let dotnet handle it -->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms" Version="17.1.0" />
-    <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.1.0" />
+    <PackageReference Include="Umbraco.Cms" Version="17.5.1" />
+    <PackageReference Include="Umbraco.Cms.DevelopmentMode.Backoffice" Version="17.5.1" />
     <PackageReference Include="uSync.Command.Setup" Version="16.1.0" />
     <ProjectReference Include="..\Clean.Core\Clean.Core.csproj" />
     <ProjectReference Include="..\Clean.Headless\Clean.Headless.csproj" />
     <ProjectReference Include="..\Clean.Models\Clean.Models.csproj" />
-    <PackageReference Include="uSync" Version="17.0.1" />
+    <PackageReference Include="uSync" Version="17.3.5" />
   </ItemGroup>
   <ItemGroup>
     <!-- Opt-in to app-local ICU to ensure consistent globalization APIs across different platforms -->

--- a/template/Clean.Core/Clean.Core.csproj
+++ b/template/Clean.Core/Clean.Core.csproj
@@ -19,7 +19,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Web.Website" Version="17.1.0" />
+    <PackageReference Include="Umbraco.Cms.Web.Website" Version="17.5.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../images/logo.png" Pack="true" PackPath="\" />

--- a/template/Clean.Headless/Clean.Headless.csproj
+++ b/template/Clean.Headless/Clean.Headless.csproj
@@ -20,8 +20,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Web.Website" Version="17.1.0" />
-    <PackageReference Include="Umbraco.Cms.Api.Common" Version="17.1.0" />
+    <PackageReference Include="Umbraco.Cms.Web.Website" Version="17.5.1" />
+    <PackageReference Include="Umbraco.Cms.Api.Common" Version="17.5.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Revalidate\" />

--- a/template/Clean.Models/Clean.Models.csproj
+++ b/template/Clean.Models/Clean.Models.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Web.Website" Version="17.1.0" />
+    <PackageReference Include="Umbraco.Cms.Web.Website" Version="17.5.1" />
   </ItemGroup>
 </Project>

--- a/template/Clean/Clean.csproj
+++ b/template/Clean/Clean.csproj
@@ -37,7 +37,7 @@
     <EmbeddedResource Include="Migrations\package.zip" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Web.Website" Version="17.1.0" />
+    <PackageReference Include="Umbraco.Cms.Web.Website" Version="17.5.1" />
     <PackageReference Include="Clean.Core" Version="7.0.7" />
     <PackageReference Include="Clean.Headless" Version="7.0.7" />
   </ItemGroup>


### PR DESCRIPTION
Updates Umbraco.Cms, Umbraco.Cms.DevelopmentMode.Backoffice, Umbraco.Cms.Web.Website and Umbraco.Cms.Api.Common from 17.1.0 to 17.5.1, and uSync from 17.0.1 to 17.3.5.